### PR TITLE
Use Ranch for TCP acceptor pool

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -93,7 +93,6 @@
 -record(basic_message, {exchange_name, routing_keys = [], content, id,
                         is_persistent}).
 
--record(ssl_socket, {tcp, ssl}).
 -record(delivery, {mandatory, confirm, sender, message, msg_seq_no, flow}).
 -record(amqp_error, {name, explanation = "", method = none}).
 

--- a/src/rabbit_net.erl
+++ b/src/rabbit_net.erl
@@ -16,6 +16,7 @@
 
 -module(rabbit_net).
 -include("rabbit.hrl").
+-include_lib("ssl/src/ssl_api.hrl").
 
 -export([is_ssl/1, ssl_info/1, controlling_process/2, getstat/2,
          recv/1, sync_recv/2, async_recv/3, port_command/2, getopts/2,
@@ -33,7 +34,7 @@
         'send_cnt' | 'send_max' | 'send_avg' | 'send_oct' | 'send_pend').
 -type(ok_val_or_error(A) :: rabbit_types:ok_or_error2(A, any())).
 -type(ok_or_any_error() :: rabbit_types:ok_or_error(any())).
--type(socket() :: port() | #ssl_socket{}).
+-type(socket() :: port() | ssl:sslsocket()).
 -type(opts() :: [{atom(), any()} |
                  {raw, non_neg_integer(), non_neg_integer(), binary()}]).
 -type(host_or_ip() :: binary() | inet:ip_address()).
@@ -85,27 +86,35 @@
 
 -define(SSL_CLOSE_TIMEOUT, 5000).
 
--define(IS_SSL(Sock), is_record(Sock, ssl_socket)).
+-define(IS_SSL(Sock), is_record(Sock, sslsocket)).
 
 is_ssl(Sock) -> ?IS_SSL(Sock).
 
+%% Seems hackish. Is hackish. But the structure is stable and
+%% kept this way for backward compatibility reasons. We need
+%% it for two reasons: there are no ssl:getstat(Sock) function,
+%% and no ssl:close(Timeout) function. Both of them are being
+%% worked on as we speak.
+ssl_get_socket(Sock) ->
+    element(2, element(2, Sock)).
+
 ssl_info(Sock) when ?IS_SSL(Sock) ->
-    ssl_compat:connection_information(Sock#ssl_socket.ssl);
+    ssl_compat:connection_information(Sock);
 ssl_info(_Sock) ->
     nossl.
 
 controlling_process(Sock, Pid) when ?IS_SSL(Sock) ->
-    ssl:controlling_process(Sock#ssl_socket.ssl, Pid);
+    ssl:controlling_process(Sock, Pid);
 controlling_process(Sock, Pid) when is_port(Sock) ->
     gen_tcp:controlling_process(Sock, Pid).
 
 getstat(Sock, Stats) when ?IS_SSL(Sock) ->
-    inet:getstat(Sock#ssl_socket.tcp, Stats);
+    inet:getstat(ssl_get_socket(Sock), Stats);
 getstat(Sock, Stats) when is_port(Sock) ->
     inet:getstat(Sock, Stats).
 
 recv(Sock) when ?IS_SSL(Sock) ->
-    recv(Sock#ssl_socket.ssl, {ssl, ssl_closed, ssl_error});
+    recv(Sock, {ssl, ssl_closed, ssl_error});
 recv(Sock) when is_port(Sock) ->
     recv(Sock, {tcp, tcp_closed, tcp_error}).
 
@@ -118,7 +127,7 @@ recv(S, {DataTag, ClosedTag, ErrorTag}) ->
     end.
 
 sync_recv(Sock, Length) when ?IS_SSL(Sock) ->
-    ssl:recv(Sock#ssl_socket.ssl, Length);
+    ssl:recv(Sock, Length);
 sync_recv(Sock, Length) ->
     gen_tcp:recv(Sock, Length).
 
@@ -127,7 +136,7 @@ async_recv(Sock, Length, Timeout) when ?IS_SSL(Sock) ->
     Ref = make_ref(),
 
     spawn(fun () -> Pid ! {inet_async, Sock, Ref,
-                           ssl:recv(Sock#ssl_socket.ssl, Length, Timeout)}
+                           ssl:recv(Sock, Length, Timeout)}
           end),
 
     {ok, Ref};
@@ -137,7 +146,7 @@ async_recv(Sock, Length, Timeout) when is_port(Sock) ->
     prim_inet:async_recv(Sock, Length, Timeout).
 
 port_command(Sock, Data) when ?IS_SSL(Sock) ->
-    case ssl:send(Sock#ssl_socket.ssl, Data) of
+    case ssl:send(Sock, Data) of
         ok              -> self() ! {inet_reply, Sock, ok},
                            true;
         {error, Reason} -> erlang:error(Reason)
@@ -146,19 +155,19 @@ port_command(Sock, Data) when is_port(Sock) ->
     erlang:port_command(Sock, Data).
 
 getopts(Sock, Options) when ?IS_SSL(Sock) ->
-    ssl:getopts(Sock#ssl_socket.ssl, Options);
+    ssl:getopts(Sock, Options);
 getopts(Sock, Options) when is_port(Sock) ->
     inet:getopts(Sock, Options).
 
 setopts(Sock, Options) when ?IS_SSL(Sock) ->
-    ssl:setopts(Sock#ssl_socket.ssl, Options);
+    ssl:setopts(Sock, Options);
 setopts(Sock, Options) when is_port(Sock) ->
     inet:setopts(Sock, Options).
 
-send(Sock, Data) when ?IS_SSL(Sock) -> ssl:send(Sock#ssl_socket.ssl, Data);
+send(Sock, Data) when ?IS_SSL(Sock) -> ssl:send(Sock, Data);
 send(Sock, Data) when is_port(Sock) -> gen_tcp:send(Sock, Data).
 
-close(Sock)      when ?IS_SSL(Sock) -> ssl:close(Sock#ssl_socket.ssl);
+close(Sock)      when ?IS_SSL(Sock) -> ssl:close(Sock);
 close(Sock)      when is_port(Sock) -> gen_tcp:close(Sock).
 
 fast_close(Sock) when ?IS_SSL(Sock) ->
@@ -173,7 +182,7 @@ fast_close(Sock) when ?IS_SSL(Sock) ->
     %% 0), which may never return if the client doesn't send a FIN or
     %% that gets swallowed by the network. Since there is no timeout
     %% variant of ssl:close, we construct our own.
-    {Pid, MRef} = spawn_monitor(fun () -> ssl:close(Sock#ssl_socket.ssl) end),
+    {Pid, MRef} = spawn_monitor(fun () -> ssl:close(Sock) end),
     erlang:send_after(?SSL_CLOSE_TIMEOUT, self(), {Pid, ssl_close_timeout}),
     receive
         {Pid, ssl_close_timeout} ->
@@ -182,18 +191,18 @@ fast_close(Sock) when ?IS_SSL(Sock) ->
         {'DOWN', MRef, process, Pid, _Reason} ->
             ok
     end,
-    catch port_close(Sock#ssl_socket.tcp),
+    catch port_close(ssl_get_socket(Sock)),
     ok;
 fast_close(Sock) when is_port(Sock) ->
     catch port_close(Sock), ok.
 
-sockname(Sock)   when ?IS_SSL(Sock) -> ssl:sockname(Sock#ssl_socket.ssl);
+sockname(Sock)   when ?IS_SSL(Sock) -> ssl:sockname(Sock);
 sockname(Sock)   when is_port(Sock) -> inet:sockname(Sock).
 
-peername(Sock)   when ?IS_SSL(Sock) -> ssl:peername(Sock#ssl_socket.ssl);
+peername(Sock)   when ?IS_SSL(Sock) -> ssl:peername(Sock);
 peername(Sock)   when is_port(Sock) -> inet:peername(Sock).
 
-peercert(Sock)   when ?IS_SSL(Sock) -> ssl:peercert(Sock#ssl_socket.ssl);
+peercert(Sock)   when ?IS_SSL(Sock) -> ssl:peercert(Sock);
 peercert(Sock)   when is_port(Sock) -> nossl.
 
 connection_string(Sock, Direction) ->

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -697,7 +697,7 @@ close_connection(State = #v1{queue_collector = Collector,
 %% tuning was never performed or didn't finish. In such cases
 %% there's also nothing to clean up.
 clean_up_exclusive_queues(undefined) ->
-    ok.
+    ok;
 
 clean_up_exclusive_queues(Collector) ->
     rabbit_queue_collector:delete_all(Collector).


### PR DESCRIPTION
Part of https://github.com/rabbitmq/rabbitmq-server/issues/260.

I didn't add a dependency on Ranch yet; I suspect rabbit_common
is used by more than the server, and we would depend on Ranch
even for unrelated things. I will need to check this before
merging.