### PR TITLE
Add file_cache_handler and buffer tuning back

### DIFF
--- a/src/rabbit_net.erl
+++ b/src/rabbit_net.erl
@@ -29,7 +29,8 @@
 -export([is_ssl/1, ssl_info/1, controlling_process/2, getstat/2,
          recv/1, sync_recv/2, async_recv/3, port_command/2, getopts/2,
          setopts/2, send/2, close/1, fast_close/1, sockname/1, peername/1,
-         peercert/1, connection_string/2, socket_ends/2, is_loopback/1]).
+         peercert/1, connection_string/2, socket_ends/2, is_loopback/1,
+         accept_ack/2]).
 
 %%---------------------------------------------------------------------------
 
@@ -87,6 +88,7 @@
         -> ok_val_or_error({host_or_ip(), rabbit_networking:ip_port(),
                             host_or_ip(), rabbit_networking:ip_port()})).
 -spec(is_loopback/1 :: (socket() | inet:ip_address()) -> boolean()).
+-spec(accept_ack/2 :: (any(), socket()) -> ok).
 
 -endif.
 
@@ -261,3 +263,19 @@ is_loopback({0,0,0,0,0,65535,AB,CD}) -> is_loopback(ipv4(AB, CD));
 is_loopback(_)                       -> false.
 
 ipv4(AB, CD) -> {AB bsr 8, AB band 255, CD bsr 8, CD band 255}.
+
+accept_ack(Ref, Sock) ->
+    ok = ranch:accept_ack(Ref),
+    case tune_buffer_size(Sock) of
+        ok         -> ok;
+        {error, _} -> rabbit_net:fast_close(Sock),
+                      exit(normal)
+    end,
+    ok = file_handle_cache:obtain().
+
+tune_buffer_size(Sock) ->
+    case getopts(Sock, [sndbuf, recbuf, buffer]) of
+        {ok, BufSizes} -> BufSz = lists:max([Sz || {_Opt, Sz} <- BufSizes]),
+                          setopts(Sock, [{buffer, BufSz}]);
+        Error          -> Error
+    end.

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -228,8 +228,8 @@ shutdown(Pid, Explanation) ->
     gen_server:call(Pid, {shutdown, Explanation}, infinity).
 
 init(Parent, HelperSup, Ref, Sock) ->
+    rabbit_net:accept_ack(Ref, Sock),
     Deb = sys:debug_options([]),
-    ok = ranch:accept_ack(Ref),
     start_connection(Parent, HelperSup, Deb, Sock).
 
 system_continue(Parent, Deb, {Buf, BufLen, State}) ->


### PR DESCRIPTION
These were removed by mistake when switching to Ranch.

The file_cache_handler used to be the acceptor doing the obtaining
(before even having an actual socket accepted), then transferring
the ownership to the new process. This has changed a little: now
the reader process claims the socket directly, saving one step.

The buffer tuning is now performed by the reader because Ranch does
not allow operations right after accepting. I have taken a note of
this and will improve this behavior with a future Ranch release.

Part of https://github.com/rabbitmq/rabbitmq-server/issues/446