### PR TITLE
Use dynamic code loading in ssl_compat and time_compat

### DIFF
--- a/src/code_version.erl
+++ b/src/code_version.erl
@@ -33,7 +33,10 @@
 %% in ERTS 7.0, while providing compatibility with previous versions.
 %%
 %% `Module` must contain an attribute `erlang_version_support` containing a list of
-%% tuples: {OriginalFuntion, PreErlang18Function, PostErlang18Function, Arity}
+%% tuples:
+%%
+%% {ErlangVersion, [{OriginalFuntion, PreErlangVersionFunction,
+%%                   PostErlangVersionFunction, Arity}]}
 %%
 %% All these new functions may be exported, and implemented as follows:
 %%
@@ -41,11 +44,11 @@
 %%    code_version:update(?MODULE),
 %%    ?MODULE:OriginalFunction().
 %%
-%% PostErlang18Function() ->
+%% PostErlangVersionFunction() ->
 %%    %% implementation using new time API
 %%    ..
 %%
-%% PreErlang18Function() ->
+%% PreErlangVersionFunction() ->
 %%    %% implementation using fallback solution
 %%    ..
 %%

--- a/src/code_version.erl
+++ b/src/code_version.erl
@@ -1,0 +1,184 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ Federation.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+-module(code_version).
+
+-export([update/1]).
+
+update(Module) ->
+    AbsCode = get_abs_code(Module),
+    Forms = replace_forms(Module, get_otp_version() >= 18, AbsCode),
+    Code = compile_forms(Forms),
+    load_code(Module, Code).
+
+load_code(Module, Code) ->
+    unload(Module),
+    case code:load_binary(Module, "loaded by rabbit_common", Code) of
+        {module, _} ->
+            ok;
+        {error, _Reason} ->
+            throw(cannot_load)
+    end.
+
+unload(Module) ->
+    code:soft_purge(Module),
+    code:delete(Module).
+
+compile_forms(Forms) ->
+    case compile:forms(Forms, [debug_info]) of
+        {ok, _ModName, Code} ->
+            Code;
+        {ok, _ModName, Code, _Warnings} ->
+            Code;
+        _ ->
+            throw(cannot_compile_forms)
+    end.
+
+get_abs_code(Module) ->
+    get_forms(get_object_code(Module)).
+
+get_object_code(Module) ->
+    case code:get_object_code(Module) of
+        {_Mod, Code, _File} ->
+            Code;
+        error ->
+            throw(not_found)
+    end.
+
+get_forms(Code) ->
+    case beam_lib:chunks(Code, [abstract_code]) of
+        {ok, {_, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
+            Forms;
+        {ok, {_, [{abstract_code, no_abstract_code}]}} ->
+            throw(no_abstract_code);
+        {error, beam_lib, Reason} ->
+            throw({no_abstract_code, Reason})
+    end.
+
+get_otp_version() ->
+    Version = erlang:system_info(otp_release),
+    case re:run(Version, "^[0-9][0-9]", [{capture, first, list}]) of
+        {match, [V]} ->
+            list_to_integer(V);
+        _ ->
+            %% Could be anything below R17, we are not interested
+            0
+    end.
+
+get_original_pairs(VersionSupport) ->
+    [{Orig, Arity} || {Orig, _Pre, _Post, Arity} <- VersionSupport].
+
+get_delete_pairs(true, VersionSupport) ->
+    [{Pre, Arity} || {_Orig, Pre, _Post, Arity} <- VersionSupport];
+get_delete_pairs(false, VersionSupport) ->
+    [{Post, Arity} || {_Orig, _Pre, Post, Arity} <- VersionSupport].
+
+get_rename_pairs(true, VersionSupport) ->
+    [{Post, Arity} || {_Orig, _Pre, Post, Arity} <- VersionSupport];
+get_rename_pairs(false, VersionSupport) ->
+    [{Pre, Arity} || {_Orig, Pre, _Post, Arity} <- VersionSupport].
+
+get_name_pairs(true, VersionSupport) ->
+    [{Post, Orig} || {Orig, _Pre, Post, _Arity} <- VersionSupport];
+get_name_pairs(false, VersionSupport) ->
+    [{Pre, Orig} || {Orig, Pre, _Post, _Arity} <- VersionSupport].
+
+delete_abstract_functions(ToDelete) ->
+    fun(Tree, Function) ->
+            case lists:member(Function, ToDelete) of
+                true ->
+                    erl_syntax:comment(["Deleted unused function"]);
+                false ->
+                    Tree
+            end
+    end.
+
+rename_abstract_functions(ToRename, ToName) ->
+    fun(Tree, {Name, _Arity} = Function) ->
+            case lists:member(Function, ToRename) of
+                true ->
+                    FunctionName = proplists:get_value(Name, ToName),
+                    erl_syntax:function(
+                      erl_syntax:atom(FunctionName),
+                      erl_syntax:function_clauses(Tree));
+                false ->
+                    Tree
+            end
+    end.
+
+replace_forms(Module, IsPost18, AbsCode) ->
+    Attr = Module:module_info(attributes),
+    VersionSupport = proplists:get_value(version_support, Attr),
+    Original = get_original_pairs(VersionSupport),
+    ToDelete = get_delete_pairs(IsPost18, VersionSupport),
+    DeleteFun = delete_abstract_functions(ToDelete ++ Original),
+    AbsCode0 = replace_function_forms(AbsCode, DeleteFun),
+    ToRename = get_rename_pairs(IsPost18, VersionSupport),
+    ToName = get_name_pairs(IsPost18, VersionSupport),
+    RenameFun = rename_abstract_functions(ToRename, ToName),
+    remove_exports(replace_function_forms(AbsCode0, RenameFun), ToDelete ++ ToRename).
+
+replace_function_forms(AbsCode, Fun) ->
+    ReplaceFunction =
+        fun(Tree) ->
+                case erl_syntax_lib:analyze_function(Tree) of
+                    {_N, _A} = Function ->
+                        Fun(Tree, Function);
+                    _Other -> Tree
+                end
+        end,
+    Filter = fun(Tree) ->
+                     case erl_syntax:type(Tree) of
+                         function -> ReplaceFunction(Tree);
+                         _Other -> Tree
+                     end
+             end,
+    fold_syntax_tree(Filter, AbsCode).
+
+filter_export_pairs(Info, ToDelete) ->
+    lists:filter(fun(Pair) ->
+                         not lists:member(Pair, ToDelete)
+                 end, Info).
+
+remove_exports(AbsCode, ToDelete) ->
+    RemoveExports =
+        fun(Tree) ->
+                case erl_syntax_lib:analyze_attribute(Tree) of
+                    {export, Info} ->
+                        Remaining = filter_export_pairs(Info, ToDelete),
+                        rebuild_export(Remaining);
+                    _Other -> Tree
+                end
+        end,
+    Filter = fun(Tree) ->
+                     case erl_syntax:type(Tree) of
+                         attribute -> RemoveExports(Tree);
+                         _Other -> Tree
+                     end
+             end,
+    fold_syntax_tree(Filter, AbsCode).
+
+rebuild_export(Args) ->
+    erl_syntax:attribute(
+      erl_syntax:atom(export),
+      [erl_syntax:list(
+         [erl_syntax:arity_qualifier(erl_syntax:atom(N),
+                                     erl_syntax:integer(A))
+          || {N, A} <- Args])]).
+
+fold_syntax_tree(Filter, Forms) ->
+    Tree = erl_syntax:form_list(Forms),
+    NewTree = erl_syntax_lib:map(Filter, Tree),
+    erl_syntax:revert_forms(NewTree).

--- a/src/code_version.erl
+++ b/src/code_version.erl
@@ -186,11 +186,8 @@ replace_forms(Module, IsPost18, AbsCode) ->
 replace_function_forms(AbsCode, Fun) ->
     ReplaceFunction =
         fun(Tree) ->
-                case erl_syntax_lib:analyze_function(Tree) of
-                    {_N, _A} = Function ->
-                        Fun(Tree, Function);
-                    _Other -> Tree
-                end
+                Function = erl_syntax_lib:analyze_function(Tree),
+                Fun(Tree, Function)
         end,
     Filter = fun(Tree) ->
                      case erl_syntax:type(Tree) of

--- a/src/code_version.erl
+++ b/src/code_version.erl
@@ -35,8 +35,8 @@
 %% `Module` must contain an attribute `erlang_version_support` containing a list of
 %% tuples:
 %%
-%% {ErlangVersion, [{OriginalFuntion, PreErlangVersionFunction,
-%%                   PostErlangVersionFunction, Arity}]}
+%% {ErlangVersion, [{OriginalFuntion, Arity, PreErlangVersionFunction,
+%%                   PostErlangVersionFunction}]}
 %%
 %% All these new functions may be exported, and implemented as follows:
 %%
@@ -121,23 +121,23 @@ get_otp_version() ->
     end.
 
 get_original_pairs(VersionSupport) ->
-    [{Orig, Arity} || {Orig, _Pre, _Post, Arity} <- VersionSupport].
+    [{Orig, Arity} || {Orig, Arity, _Pre, _Post} <- VersionSupport].
 
 get_delete_pairs(true, VersionSupport) ->
-    [{Pre, Arity} || {_Orig, Pre, _Post, Arity} <- VersionSupport];
+    [{Pre, Arity} || {_Orig, Arity, Pre, _Post} <- VersionSupport];
 get_delete_pairs(false, VersionSupport) ->
-    [{Post, Arity} || {_Orig, _Pre, Post, Arity} <- VersionSupport].
+    [{Post, Arity} || {_Orig, Arity, _Pre, Post} <- VersionSupport].
 
 get_rename_pairs(true, VersionSupport) ->
-    [{Post, Arity} || {_Orig, _Pre, Post, Arity} <- VersionSupport];
+    [{Post, Arity} || {_Orig, Arity, _Pre, Post} <- VersionSupport];
 get_rename_pairs(false, VersionSupport) ->
-    [{Pre, Arity} || {_Orig, Pre, _Post, Arity} <- VersionSupport].
+    [{Pre, Arity} || {_Orig, Arity, Pre, _Post} <- VersionSupport].
 
 %% Pairs of {Renamed, OriginalName} functions
 get_name_pairs(true, VersionSupport) ->
-    [{{Post, Arity}, Orig} || {Orig, _Pre, Post, Arity} <- VersionSupport];
+    [{{Post, Arity}, Orig} || {Orig, Arity, _Pre, Post} <- VersionSupport];
 get_name_pairs(false, VersionSupport) ->
-    [{{Pre, Arity}, Orig} || {Orig, Pre, _Post, Arity} <- VersionSupport].
+    [{{Pre, Arity}, Orig} || {Orig, Arity, Pre, _Post} <- VersionSupport].
 
 delete_abstract_functions(ToDelete) ->
     fun(Tree, Function) ->

--- a/src/code_version.erl
+++ b/src/code_version.erl
@@ -132,9 +132,9 @@ get_rename_pairs(false, VersionSupport) ->
 
 %% Pairs of {Renamed, OriginalName} functions
 get_name_pairs(true, VersionSupport) ->
-    [{Post, Orig} || {Orig, _Pre, Post, _Arity} <- VersionSupport];
+    [{{Post, Arity}, Orig} || {Orig, _Pre, Post, Arity} <- VersionSupport];
 get_name_pairs(false, VersionSupport) ->
-    [{Pre, Orig} || {Orig, Pre, _Post, _Arity} <- VersionSupport].
+    [{{Pre, Arity}, Orig} || {Orig, Pre, _Post, Arity} <- VersionSupport].
 
 delete_abstract_functions(ToDelete) ->
     fun(Tree, Function) ->
@@ -147,10 +147,10 @@ delete_abstract_functions(ToDelete) ->
     end.
 
 rename_abstract_functions(ToRename, ToName) ->
-    fun(Tree, {Name, _Arity} = Function) ->
+    fun(Tree, Function) ->
             case lists:member(Function, ToRename) of
                 true ->
-                    FunctionName = proplists:get_value(Name, ToName),
+                    FunctionName = proplists:get_value(Function, ToName),
                     erl_syntax:function(
                       erl_syntax:atom(FunctionName),
                       erl_syntax:function_clauses(Tree));

--- a/src/ssl_compat.erl
+++ b/src/ssl_compat.erl
@@ -20,44 +20,60 @@
 %% this module.
 -compile(nowarn_deprecated_function).
 
+%% Declare versioned functions to allow dynamic code loading,
+%% depending on the Erlang version running. See 'code_version.erl' for details
+-version_support(
+   [{connection_information, connection_information_pre_18,
+     connection_information_post_18, 1},
+    {connection_information, connection_information_pre_18,
+     connection_information_post_18, 2}]).
+
 -export([connection_information/1,
-         connection_information/2]).
+         connection_information_pre_18/1,
+         connection_information_post_18/1,
+         connection_information/2,
+         connection_information_pre_18/2,
+         connection_information_post_18/2]).
 
 connection_information(SslSocket) ->
-    try
-        ssl:connection_information(SslSocket)
-    catch
-        error:undef ->
-            case ssl:connection_info(SslSocket) of
-                {ok, {ProtocolVersion, CipherSuite}} ->
-                    {ok, [{protocol, ProtocolVersion},
-                          {cipher_suite, CipherSuite}]};
-                {error, Reason} ->
-                    {error, Reason}
-            end
+    code_version:update(?MODULE),
+    ssl_compat:connection_information(SslSocket).
+
+connection_information_post_18(SslSocket) ->
+    ssl:connection_information(SslSocket).
+
+connection_information_pre_18(SslSocket) ->
+    case ssl:connection_info(SslSocket) of
+        {ok, {ProtocolVersion, CipherSuite}} ->
+            {ok, [{protocol, ProtocolVersion},
+                  {cipher_suite, CipherSuite}]};
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 connection_information(SslSocket, Items) ->
-    try
-        ssl:connection_information(SslSocket, Items)
-    catch
-        error:undef ->
-            WantProtocolVersion = lists:member(protocol, Items),
-            WantCipherSuite = lists:member(cipher_suite, Items),
-            if
-                WantProtocolVersion orelse WantCipherSuite ->
-                    case ssl:connection_info(SslSocket) of
-                        {ok, {ProtocolVersion, CipherSuite}} ->
-                            filter_information_items(ProtocolVersion,
-                                                     CipherSuite,
-                                                     Items,
-                                                     []);
-                        {error, Reason} ->
-                            {error, Reason}
-                    end;
-                true ->
-                    {ok, []}
-            end
+    code_version:update(?MODULE),
+    ssl_compat:connection_information(SslSocket, Items).
+
+connection_information_post_18(SslSocket, Items) ->
+    ssl:connection_information(SslSocket, Items).
+
+connection_information_pre_18(SslSocket, Items) ->
+    WantProtocolVersion = lists:member(protocol, Items),
+    WantCipherSuite = lists:member(cipher_suite, Items),
+    if
+        WantProtocolVersion orelse WantCipherSuite ->
+            case ssl:connection_info(SslSocket) of
+                {ok, {ProtocolVersion, CipherSuite}} ->
+                    filter_information_items(ProtocolVersion,
+                                             CipherSuite,
+                                             Items,
+                                             []);
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        true ->
+            {ok, []}
     end.
 
 filter_information_items(ProtocolVersion, CipherSuite, [protocol | Rest],

--- a/src/ssl_compat.erl
+++ b/src/ssl_compat.erl
@@ -23,10 +23,10 @@
 %% Declare versioned functions to allow dynamic code loading,
 %% depending on the Erlang version running. See 'code_version.erl' for details
 -erlang_version_support(
-   [{18, [{connection_information, connection_information_pre_18,
-           connection_information_post_18, 1},
-          {connection_information, connection_information_pre_18,
-           connection_information_post_18, 2}]}
+   [{18, [{connection_information, 1, connection_information_pre_18,
+           connection_information_post_18},
+          {connection_information, 2, connection_information_pre_18,
+           connection_information_post_18}]}
    ]).
 
 -export([connection_information/1,

--- a/src/ssl_compat.erl
+++ b/src/ssl_compat.erl
@@ -22,11 +22,12 @@
 
 %% Declare versioned functions to allow dynamic code loading,
 %% depending on the Erlang version running. See 'code_version.erl' for details
--version_support(
-   [{connection_information, connection_information_pre_18,
-     connection_information_post_18, 1},
-    {connection_information, connection_information_pre_18,
-     connection_information_post_18, 2}]).
+-erlang_version_support(
+   [{18, [{connection_information, connection_information_pre_18,
+           connection_information_post_18, 1},
+          {connection_information, connection_information_pre_18,
+           connection_information_post_18, 2}]}
+   ]).
 
 -export([connection_information/1,
          connection_information_pre_18/1,

--- a/src/time_compat.erl
+++ b/src/time_compat.erl
@@ -116,21 +116,12 @@ monotonic_time(Unit) ->
     time_compat:monotonic_time(Unit).
 
 monotonic_time_post_18(Unit) ->
-    try
-        erlang:monotonic_time(Unit)
-    catch
-        error:badarg ->
-            erlang:error(badarg, [Unit])
-    end.
+    erlang:monotonic_time(Unit).
 
 monotonic_time_pre_18(Unit) ->
     %% Use Erlang system time as monotonic time
     STime = erlang_system_time_fallback(),
-    try
-		convert_time_unit_fallback(STime, native, Unit)
-    catch
-		error:bad_time_unit -> erlang:error(badarg, [Unit])
-    end.
+    convert_time_unit_fallback(STime, native, Unit).
 
 erlang_system_time() ->
     code_version:update(?MODULE),
@@ -147,20 +138,11 @@ erlang_system_time(Unit) ->
     time_compat:erlang_system_time(Unit).
 
 erlang_system_time_post_18(Unit) ->
-    try
-        erlang:system_time(Unit)
-    catch
-        error:badarg ->
-            erlang:error(badarg, [Unit])
-    end.
+    erlang:system_time(Unit).
 
 erlang_system_time_pre_18(Unit) ->
     STime = erlang_system_time_fallback(),
-    try
-		convert_time_unit_fallback(STime, native, Unit)
-    catch
-		error:bad_time_unit -> erlang:error(badarg, [Unit])
-    end.
+    convert_time_unit_fallback(STime, native, Unit).
 
 os_system_time() ->
     code_version:update(?MODULE),
@@ -177,20 +159,11 @@ os_system_time(Unit) ->
     time_compat:os_system_time(Unit).
 
 os_system_time_post_18(Unit) ->
-    try
-        os:system_time(Unit)
-    catch
-        error:badarg ->
-            erlang:error(badarg, [Unit])
-    end.
+    os:system_time(Unit).
 
 os_system_time_pre_18(Unit) ->
     STime = os_system_time_fallback(),
-    try
-		convert_time_unit_fallback(STime, native, Unit)
-    catch
-		error:bad_time_unit -> erlang:error(badarg, [Unit])
-    end.
+    convert_time_unit_fallback(STime, native, Unit).
 
 time_offset() ->
     code_version:update(?MODULE),
@@ -209,19 +182,10 @@ time_offset(Unit) ->
     time_compat:time_offset(Unit).
 
 time_offset_post_18(Unit) ->
-    try
-        erlang:time_offset(Unit)
-    catch
-        error:badarg ->
-            erlang:error(badarg, [Unit])
-    end.
+    erlang:time_offset(Unit).
 
 time_offset_pre_18(Unit) ->
-    try
-        _ = integer_time_unit(Unit)
-    catch
-		error:bad_time_unit -> erlang:error(badarg, [Unit])
-    end,
+    _ = integer_time_unit(Unit),
     %% Erlang system time and Erlang monotonic
     %% time are always aligned
     0.
@@ -272,12 +236,7 @@ unique_integer(Modifiers) ->
     time_compat:unique_integer(Modifiers).
 
 unique_integer_post_18(Modifiers) ->
-    try
-        erlang:unique_integer(Modifiers)
-    catch
-        error:badarg ->
-            erlang:error(badarg, [Modifiers])
-    end.
+    erlang:unique_integer(Modifiers).
 
 unique_integer_pre_18(Modifiers) ->
     case is_valid_modifier_list(Modifiers) of
@@ -360,7 +319,7 @@ integer_time_unit(micro_seconds) -> 1000*1000;
 integer_time_unit(milli_seconds) -> 1000;
 integer_time_unit(seconds) -> 1;
 integer_time_unit(I) when is_integer(I), I > 0 -> I;
-integer_time_unit(BadRes) -> erlang:error(bad_time_unit, [BadRes]).
+integer_time_unit(BadRes) -> erlang:error(badarg, [BadRes]).
 
 erlang_system_time_fallback() ->
     {MS, S, US} = erlang:now(),

--- a/src/time_compat.erl
+++ b/src/time_compat.erl
@@ -54,7 +54,7 @@
     {os_system_time, os_system_time_pre_18, os_system_time_post_18, 1},
     {time_offset, time_offset_pre_18, time_offset_post_18, 0},
     {time_offset, time_offset_pre_18, time_offset_post_18, 1},
-    {convert_time_unit, convert_time_unit_pre_18, convert_time_unit_post_18, 0},
+    {convert_time_unit, convert_time_unit_pre_18, convert_time_unit_post_18, 3},
     {timestamp, timestamp_pre_18, timestamp_post_18, 0},
     {unique_integer, unique_integer_pre_18, unique_integer_post_18, 0},
     {unique_integer, unique_integer_pre_18, unique_integer_post_18, 1}]).

--- a/src/time_compat.erl
+++ b/src/time_compat.erl
@@ -47,18 +47,18 @@
 %% depending on the Erlang version running. See 'code_version.erl' for details
 -erlang_version_support(
    [{18,
-     [{monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 0},
-      {monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 1},
-      {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 0},
-      {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 1},
-      {os_system_time, os_system_time_pre_18, os_system_time_post_18, 0},
-      {os_system_time, os_system_time_pre_18, os_system_time_post_18, 1},
-      {time_offset, time_offset_pre_18, time_offset_post_18, 0},
-      {time_offset, time_offset_pre_18, time_offset_post_18, 1},
-      {convert_time_unit, convert_time_unit_pre_18, convert_time_unit_post_18, 3},
-      {timestamp, timestamp_pre_18, timestamp_post_18, 0},
-      {unique_integer, unique_integer_pre_18, unique_integer_post_18, 0},
-      {unique_integer, unique_integer_pre_18, unique_integer_post_18, 1}]}
+     [{monotonic_time, 0, monotonic_time_pre_18, monotonic_time_post_18},
+      {monotonic_time, 1, monotonic_time_pre_18, monotonic_time_post_18},
+      {erlang_system_time, 0, erlang_system_time_pre_18, erlang_system_time_post_18},
+      {erlang_system_time, 1, erlang_system_time_pre_18, erlang_system_time_post_18},
+      {os_system_time, 0, os_system_time_pre_18, os_system_time_post_18},
+      {os_system_time, 1, os_system_time_pre_18, os_system_time_post_18},
+      {time_offset, 0, time_offset_pre_18, time_offset_post_18},
+      {time_offset, 1, time_offset_pre_18, time_offset_post_18},
+      {convert_time_unit, 3, convert_time_unit_pre_18, convert_time_unit_post_18},
+      {timestamp, 0, timestamp_pre_18, timestamp_post_18},
+      {unique_integer, 0, unique_integer_pre_18, unique_integer_post_18},
+      {unique_integer, 1, unique_integer_pre_18, unique_integer_post_18}]}
    ]).
 
 -export([monotonic_time/0,

--- a/src/time_compat.erl
+++ b/src/time_compat.erl
@@ -45,19 +45,21 @@
 
 %% Declare versioned functions to allow dynamic code loading,
 %% depending on the Erlang version running. See 'code_version.erl' for details
--version_support(
-   [{monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 0},
-    {monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 1},
-    {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 0},
-    {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 1},
-    {os_system_time, os_system_time_pre_18, os_system_time_post_18, 0},
-    {os_system_time, os_system_time_pre_18, os_system_time_post_18, 1},
-    {time_offset, time_offset_pre_18, time_offset_post_18, 0},
-    {time_offset, time_offset_pre_18, time_offset_post_18, 1},
-    {convert_time_unit, convert_time_unit_pre_18, convert_time_unit_post_18, 3},
-    {timestamp, timestamp_pre_18, timestamp_post_18, 0},
-    {unique_integer, unique_integer_pre_18, unique_integer_post_18, 0},
-    {unique_integer, unique_integer_pre_18, unique_integer_post_18, 1}]).
+-erlang_version_support(
+   [{18,
+     [{monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 0},
+      {monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 1},
+      {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 0},
+      {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 1},
+      {os_system_time, os_system_time_pre_18, os_system_time_post_18, 0},
+      {os_system_time, os_system_time_pre_18, os_system_time_post_18, 1},
+      {time_offset, time_offset_pre_18, time_offset_post_18, 0},
+      {time_offset, time_offset_pre_18, time_offset_post_18, 1},
+      {convert_time_unit, convert_time_unit_pre_18, convert_time_unit_post_18, 3},
+      {timestamp, timestamp_pre_18, timestamp_post_18, 0},
+      {unique_integer, unique_integer_pre_18, unique_integer_post_18, 0},
+      {unique_integer, unique_integer_pre_18, unique_integer_post_18, 1}]}
+   ]).
 
 -export([monotonic_time/0,
          monotonic_time_pre_18/0,

--- a/src/time_compat.erl
+++ b/src/time_compat.erl
@@ -43,160 +43,240 @@
 %% where it has not yet been deprecated.
 %%
 
+-version_support(
+   [{monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 0},
+    {monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 1},
+    {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 0},
+    {erlang_system_time, erlang_system_time_pre_18, erlang_system_time_post_18, 1},
+    {os_system_time, os_system_time_pre_18, os_system_time_post_18, 0},
+    {os_system_time, os_system_time_pre_18, os_system_time_post_18, 1},
+    {time_offset, time_offset_pre_18, time_offset_post_18, 0},
+    {time_offset, time_offset_pre_18, time_offset_post_18, 1},
+    {convert_time_unit, convert_time_unit_pre_18, convert_time_unit_post_18, 0},
+    {timestamp, timestamp_pre_18, timestamp_post_18, 0},
+    {unique_integer, unique_integer_pre_18, unique_integer_post_18, 0},
+    {unique_integer, unique_integer_pre_18, unique_integer_post_18, 1}]).
+
 -export([monotonic_time/0,
-	 monotonic_time/1,
-	 erlang_system_time/0,
-	 erlang_system_time/1,
-	 os_system_time/0,
-	 os_system_time/1,
-	 time_offset/0,
-	 time_offset/1,
-	 convert_time_unit/3,
-	 timestamp/0,
-	 unique_integer/0,
-	 unique_integer/1,
-	 monitor/2,
-	 system_info/1,
-	 system_flag/2]).
+         monotonic_time_pre_18/0,
+         monotonic_time_post_18/0,
+         monotonic_time/1,
+         monotonic_time_pre_18/1,
+         monotonic_time_post_18/1,
+         erlang_system_time/0,
+         erlang_system_time_pre_18/0,
+         erlang_system_time_post_18/0,
+         erlang_system_time/1,
+         erlang_system_time_pre_18/1,
+         erlang_system_time_post_18/1,
+         os_system_time/0,
+         os_system_time_pre_18/0,
+         os_system_time_post_18/0,
+         os_system_time/1,
+         os_system_time_pre_18/1,
+         os_system_time_post_18/1,
+         time_offset/0,
+         time_offset_pre_18/0,
+         time_offset_post_18/0,
+         time_offset/1,
+         time_offset_pre_18/1,
+         time_offset_post_18/1,
+         convert_time_unit/3,
+         convert_time_unit_pre_18/3,
+         convert_time_unit_post_18/3,
+         timestamp/0,
+         timestamp_pre_18/0,
+         timestamp_post_18/0,
+         unique_integer/0,
+         unique_integer_pre_18/0,
+         unique_integer_post_18/0,
+         unique_integer/1,
+         unique_integer_pre_18/1,
+         unique_integer_post_18/1,
+         monitor/2,
+         system_info/1,
+         system_flag/2]).
 
 monotonic_time() ->
-    try
-	erlang:monotonic_time()
-    catch
-	error:undef ->
-	    %% Use Erlang system time as monotonic time
-	    erlang_system_time_fallback()
-    end.
+    code_version:update(?MODULE),
+    time_compat:monotonic_time().
+
+monotonic_time_post_18() ->
+	erlang:monotonic_time().
+
+monotonic_time_pre_18() ->
+    erlang_system_time_fallback().
 
 monotonic_time(Unit) ->
+    code_version:update(?MODULE),
+    time_compat:monotonic_time(Unit).
+
+monotonic_time_post_18(Unit) ->
     try
-	erlang:monotonic_time(Unit)
+        erlang:monotonic_time(Unit)
     catch
-	error:badarg ->
-	    erlang:error(badarg, [Unit]);
-	error:undef ->
-	    %% Use Erlang system time as monotonic time
-	    STime = erlang_system_time_fallback(),
-	    try
+        error:badarg ->
+            erlang:error(badarg, [Unit])
+    end.
+
+monotonic_time_pre_18(Unit) ->
+    %% Use Erlang system time as monotonic time
+    STime = erlang_system_time_fallback(),
+    try
 		convert_time_unit_fallback(STime, native, Unit)
-	    catch
+    catch
 		error:bad_time_unit -> erlang:error(badarg, [Unit])
-	    end
     end.
 
 erlang_system_time() ->
-    try
-	erlang:system_time()
-    catch
-	error:undef ->
-	    erlang_system_time_fallback()
-    end.
+    code_version:update(?MODULE),
+    time_compat:erlang_system_time().
+
+erlang_system_time_post_18() ->
+	erlang:system_time().
+
+erlang_system_time_pre_18() ->
+    erlang_system_time_fallback().
 
 erlang_system_time(Unit) ->
+    code_version:update(?MODULE),
+    time_compat:erlang_system_time(Unit).
+
+erlang_system_time_post_18(Unit) ->
     try
-	erlang:system_time(Unit)
+        erlang:system_time(Unit)
     catch
-	error:badarg ->
-	    erlang:error(badarg, [Unit]);
-	error:undef ->
-	    STime = erlang_system_time_fallback(),
-	    try
+        error:badarg ->
+            erlang:error(badarg, [Unit])
+    end.
+
+erlang_system_time_pre_18(Unit) ->
+    STime = erlang_system_time_fallback(),
+    try
 		convert_time_unit_fallback(STime, native, Unit)
-	    catch
+    catch
 		error:bad_time_unit -> erlang:error(badarg, [Unit])
-	    end
     end.
 
 os_system_time() ->
-    try
-	os:system_time()
-    catch
-	error:undef ->
-	    os_system_time_fallback()
-    end.
+    code_version:update(?MODULE),
+    time_compat:os_system_time().
+
+os_system_time_post_18() ->
+	os:system_time().
+
+os_system_time_pre_18() ->
+    os_system_time_fallback().
 
 os_system_time(Unit) ->
+    code_version:update(?MODULE),
+    time_compat:os_system_time(Unit).
+
+os_system_time_post_18(Unit) ->
     try
-	os:system_time(Unit)
+        os:system_time(Unit)
     catch
-	error:badarg ->
-	    erlang:error(badarg, [Unit]);
-	error:undef ->
-	    STime = os_system_time_fallback(),
-	    try
+        error:badarg ->
+            erlang:error(badarg, [Unit])
+    end.
+
+os_system_time_pre_18(Unit) ->
+    STime = os_system_time_fallback(),
+    try
 		convert_time_unit_fallback(STime, native, Unit)
-	    catch
+    catch
 		error:bad_time_unit -> erlang:error(badarg, [Unit])
-	    end
     end.
 
 time_offset() ->
-    try
-	erlang:time_offset()
-    catch
-	error:undef ->
-	    %% Erlang system time and Erlang monotonic
-	    %% time are always aligned
-	    0
-    end.
+    code_version:update(?MODULE),
+    time_compat:time_offset().
+
+time_offset_post_18() ->
+	erlang:time_offset().
+
+time_offset_pre_18() ->
+    %% Erlang system time and Erlang monotonic
+    %% time are always aligned
+    0.
 
 time_offset(Unit) ->
+    code_version:update(?MODULE),
+    time_compat:time_offset(Unit).
+
+time_offset_post_18(Unit) ->
     try
-	erlang:time_offset(Unit)
+        erlang:time_offset(Unit)
     catch
-	error:badarg ->
-	    erlang:error(badarg, [Unit]);
-	error:undef ->
-	    try
-		_ = integer_time_unit(Unit)
-	    catch
-		error:bad_time_unit -> erlang:error(badarg, [Unit])
-	    end,
-	    %% Erlang system time and Erlang monotonic
-	    %% time are always aligned
-	    0
+        error:badarg ->
+            erlang:error(badarg, [Unit])
     end.
 
-convert_time_unit(Time, FromUnit, ToUnit) ->
+time_offset_pre_18(Unit) ->
     try
-	erlang:convert_time_unit(Time, FromUnit, ToUnit)
+        _ = integer_time_unit(Unit)
     catch
-	error:undef ->
-	    try
-		convert_time_unit_fallback(Time, FromUnit, ToUnit)
-	    catch
-		_:_ ->
-		    erlang:error(badarg, [Time, FromUnit, ToUnit])
-	    end;
-	error:Error ->
+		error:bad_time_unit -> erlang:error(badarg, [Unit])
+    end,
+    %% Erlang system time and Erlang monotonic
+    %% time are always aligned
+    0.
+
+convert_time_unit(Time, FromUnit, ToUnit) ->
+    code_version:update(?MODULE),
+    time_compat:convert_time_unit(Time, FromUnit, ToUnit).
+
+convert_time_unit_post_18(Time, FromUnit, ToUnit) ->
+    try
+        erlang:convert_time_unit(Time, FromUnit, ToUnit)
+    catch
+        error:Error ->
 	    erlang:error(Error, [Time, FromUnit, ToUnit])
     end.
 
-timestamp() ->
+convert_time_unit_pre_18(Time, FromUnit, ToUnit) ->
     try
-	erlang:timestamp()
+        convert_time_unit_fallback(Time, FromUnit, ToUnit)
     catch
-	error:undef ->
-	    erlang:now()
+		_:_ ->
+		    erlang:error(badarg, [Time, FromUnit, ToUnit])
     end.
+
+timestamp() ->
+    code_version:update(?MODULE),
+    time_compat:timestamp().
+
+timestamp_post_18() ->
+	erlang:timestamp().
+
+timestamp_pre_18() ->
+    erlang:now().
 
 unique_integer() ->
-    try
-	erlang:unique_integer()
-    catch
-	error:undef ->
-	    {MS, S, US} = erlang:now(),
-	    (MS*1000000+S)*1000000+US
-    end.
+    code_version:update(?MODULE),
+    time_compat:unique_integer().
+
+unique_integer_post_18() ->
+	erlang:unique_integer().
+
+unique_integer_pre_18() ->
+    {MS, S, US} = erlang:now(),
+    (MS*1000000+S)*1000000+US.
 
 unique_integer(Modifiers) ->
+    code_version:update(?MODULE),
+    time_compat:unique_integer(Modifiers).
+
+unique_integer_post_18(Modifiers) ->
     try
-	erlang:unique_integer(Modifiers)
+        erlang:unique_integer(Modifiers)
     catch
-	error:badarg ->
-	    erlang:error(badarg, [Modifiers]);
-	error:undef ->
-	    case is_valid_modifier_list(Modifiers) of
+        error:badarg ->
+            erlang:error(badarg, [Modifiers])
+    end.
+
+unique_integer_pre_18(Modifiers) ->
+    case is_valid_modifier_list(Modifiers) of
 		true ->
 		    %% now() converted to an integer
 		    %% fullfill the requirements of
@@ -206,7 +286,6 @@ unique_integer(Modifiers) ->
 		    (MS*1000000+S)*1000000+US;
 		false ->
 		    erlang:error(badarg, [Modifiers])
-	    end
     end.
 
 monitor(Type, Item) ->

--- a/src/time_compat.erl
+++ b/src/time_compat.erl
@@ -43,6 +43,8 @@
 %% where it has not yet been deprecated.
 %%
 
+%% Declare versioned functions to allow dynamic code loading,
+%% depending on the Erlang version running. See 'code_version.erl' for details
 -version_support(
    [{monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 0},
     {monotonic_time, monotonic_time_pre_18, monotonic_time_post_18, 1},


### PR DESCRIPTION
Based on dynamic code load in startup/runtime. See https://github.com/rabbitmq/rabbitmq-server/issues/346#issuecomment-169980207

Solves https://github.com/rabbitmq/rabbitmq-server/issues/346 and https://github.com/rabbitmq/rabbitmq-server/issues/347