### PR TITLE
Adds handling of exit signals from socket process to rabbit_reader, when terminating channels

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -746,7 +746,8 @@ wait_for_channel_termination(N, TimerRef,
                                          connection = #connection{
                                                          name  = ConnName,
                                                          user  = User,
-                                                         vhost = VHost}}) ->
+                                                         vhost = VHost},
+                                         sock = Sock}) ->
     receive
         {'DOWN', _MRef, process, ChPid, Reason} ->
             {Channel, State1} = channel_cleanup(ChPid, State),
@@ -763,6 +764,9 @@ wait_for_channel_termination(N, TimerRef,
                          CS, Channel, Reason]),
                     wait_for_channel_termination(N-1, TimerRef, State1)
             end;
+        {'EXIT', Sock, _Reason} ->
+            [channel_cleanup(ChPid, State) || ChPid <- all_channels()],
+            exit(normal);
         cancel_wait ->
             exit(channel_termination_timeout)
     end.


### PR DESCRIPTION
Fixes rabbitmq/rabbitmq-server#544.