### PR TITLE
Update channel interceptors on register/unregister

### DIFF
--- a/src/rabbit_auth_mechanism.erl
+++ b/src/rabbit_auth_mechanism.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_auth_mechanism).
 
+-behaviour(rabbit_registry_class).
+
+-export([added_to_rabbit_registry/2, removed_from_rabbit_registry/1]).
+
 -ifdef(use_specs).
 
 %% A description.
@@ -54,3 +58,6 @@ behaviour_info(_Other) ->
     undefined.
 
 -endif.
+
+added_to_rabbit_registry(_Type, _ModuleName) -> ok.
+removed_from_rabbit_registry(_Type) -> ok.

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -150,6 +150,8 @@
 
 -define(MAX_PERMISSION_CACHE_SIZE, 12).
 
+-define(REFRESH_TIMEOUT, 15000).
+
 -define(STATISTICS_KEYS,
         [pid,
          transactional,
@@ -340,7 +342,7 @@ refresh_config_local() ->
 
 refresh_interceptors() ->
     rabbit_misc:upmap(
-      fun (C) -> gen_server2:call(C, refresh_interceptors, infinity) end,
+      fun (C) -> gen_server2:call(C, refresh_interceptors, ?REFRESH_TIMEOUT) end,
       list_local()),
     ok.    
 

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -58,6 +58,7 @@
 -export([list/0, info_keys/0, info/1, info/2, info_all/0, info_all/1,
          info_all/3]).
 -export([refresh_config_local/0, ready_for_close/1]).
+-export([refresh_interceptors/0]).
 -export([force_event_refresh/1]).
 
 -export([init/1, terminate/2, code_change/3, handle_call/3, handle_cast/2,
@@ -337,6 +338,12 @@ refresh_config_local() ->
       list_local()),
     ok.
 
+refresh_interceptors() ->
+    rabbit_misc:upmap(
+      fun (C) -> gen_server2:call(C, refresh_interceptors, infinity) end,
+      list_local()),
+    ok.    
+
 ready_for_close(Pid) ->
     gen_server2:cast(Pid, ready_for_close).
 
@@ -429,6 +436,10 @@ handle_call({info, Items}, _From, State) ->
 
 handle_call(refresh_config, _From, State = #ch{virtual_host = VHost}) ->
     reply(ok, State#ch{trace_state = rabbit_trace:init(VHost)});
+
+handle_call(refresh_interceptors, _From, State) ->
+    IState = rabbit_channel_interceptor:init(State),
+    reply(ok, State#ch{interceptor_state = IState});
 
 handle_call({declare_fast_reply_to, Key}, _From,
             State = #ch{reply_consumer = Consumer}) ->
@@ -1977,6 +1988,8 @@ i(state,                   #ch{state = State})            -> State;
 i(prefetch_count,          #ch{consumer_prefetch = C})    -> C;
 i(global_prefetch_count, #ch{limiter = Limiter}) ->
     rabbit_limiter:get_prefetch_limit(Limiter);
+i(interceptors, #ch{interceptor_state = IState}) ->
+    IState;
 i(Item, _) ->
     throw({bad_argument, Item}).
 

--- a/src/rabbit_channel_interceptor.erl
+++ b/src/rabbit_channel_interceptor.erl
@@ -20,6 +20,7 @@
 -include("rabbit.hrl").
 
 -export([init/1, intercept_in/3]).
+-export([registered/2, unregistered/1]).
 
 -ifdef(use_specs).
 
@@ -110,6 +111,11 @@ validate_method(M, M2) ->
 validate_content(none, none) -> true;
 validate_content(#content{}, #content{}) -> true;
 validate_content(_, _) -> false.
+
+
+registered(_,_) -> rabbit_channel:refresh_interceptors().
+
+unregistered(_) -> rabbit_channel:refresh_interceptors().
 
 %% keep dialyzer happy
 -spec internal_error(string(), [any()]) -> no_return().

--- a/src/rabbit_channel_interceptor.erl
+++ b/src/rabbit_channel_interceptor.erl
@@ -20,7 +20,10 @@
 -include("rabbit.hrl").
 
 -export([init/1, intercept_in/3]).
--export([registered/2, unregistered/1]).
+
+-behaviour(rabbit_registry_class).
+
+-export([added_to_rabbit_registry/2, removed_from_rabbit_registry/1]).
 
 -ifdef(use_specs).
 
@@ -51,6 +54,11 @@ behaviour_info(_Other) ->
     undefined.
 
 -endif.
+
+added_to_rabbit_registry(_Type, _ModuleName) -> 
+    rabbit_channel:refresh_interceptors().
+removed_from_rabbit_registry(_Type) -> 
+    rabbit_channel:refresh_interceptors().
 
 init(Ch) ->
     Mods = [M || {_, M} <- rabbit_registry:lookup_all(channel_interceptor)],
@@ -111,11 +119,6 @@ validate_method(M, M2) ->
 validate_content(none, none) -> true;
 validate_content(#content{}, #content{}) -> true;
 validate_content(_, _) -> false.
-
-
-registered(_,_) -> rabbit_channel:refresh_interceptors().
-
-unregistered(_) -> rabbit_channel:refresh_interceptors().
 
 %% keep dialyzer happy
 -spec internal_error(string(), [any()]) -> no_return().

--- a/src/rabbit_exchange_type.erl
+++ b/src/rabbit_exchange_type.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_exchange_type).
 
+-behaviour(rabbit_registry_class).
+
+-export([added_to_rabbit_registry/2, removed_from_rabbit_registry/1]).
+
 -ifdef(use_specs).
 
 -type(tx() :: 'transaction' | 'none').
@@ -79,3 +83,8 @@ behaviour_info(_Other) ->
     undefined.
 
 -endif.
+
+added_to_rabbit_registry(_Type, _ModuleName) -> ok.
+removed_from_rabbit_registry(_Type) -> ok.
+
+

--- a/src/rabbit_policy_validator.erl
+++ b/src/rabbit_policy_validator.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_policy_validator).
 
+-behaviour(rabbit_registry_class).
+
+-export([added_to_rabbit_registry/2, removed_from_rabbit_registry/1]).
+
 -ifdef(use_specs).
 
 -export_type([validate_results/0]).
@@ -37,3 +41,6 @@ behaviour_info(_Other) ->
     undefined.
 
 -endif.
+
+added_to_rabbit_registry(_Type, _ModuleName) -> ok.
+removed_from_rabbit_registry(_Type) -> ok.

--- a/src/rabbit_queue_decorator.erl
+++ b/src/rabbit_queue_decorator.erl
@@ -20,6 +20,10 @@
 
 -export([select/1, set/1, register/2, unregister/1]).
 
+-behaviour(rabbit_registry_class).
+
+-export([added_to_rabbit_registry/2, removed_from_rabbit_registry/1]).
+
 %%----------------------------------------------------------------------------
 
 -ifdef(use_specs).
@@ -50,6 +54,9 @@ behaviour_info(_Other) ->
 -endif.
 
 %%----------------------------------------------------------------------------
+
+added_to_rabbit_registry(_Type, _ModuleName) -> ok.
+removed_from_rabbit_registry(_Type) -> ok.
 
 select(Modules) ->
     [M || M <- Modules, code:which(M) =/= non_existing].

--- a/src/rabbit_queue_master_locator.erl
+++ b/src/rabbit_queue_master_locator.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_queue_master_locator).
 
+-behaviour(rabbit_registry_class).
+
+-export([added_to_rabbit_registry/2, removed_from_rabbit_registry/1]).
+
 -ifdef(use_specs).
 
 -callback description()                -> [proplists:property()].
@@ -31,3 +35,6 @@ behaviour_info(_Other) ->
     undefined.
 
 -endif.
+
+added_to_rabbit_registry(_Type, _ModuleName) -> ok.
+removed_from_rabbit_registry(_Type) -> ok.

--- a/src/rabbit_registry.erl
+++ b/src/rabbit_registry.erl
@@ -1,0 +1,177 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_registry).
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+         code_change/3]).
+
+-export([register/3, unregister/2,
+         binary_to_type/1, lookup_module/2, lookup_all/1]).
+
+-define(SERVER, ?MODULE).
+-define(ETS_NAME, ?MODULE).
+
+-ifdef(use_specs).
+
+-spec(start_link/0 :: () -> rabbit_types:ok_pid_or_error()).
+-spec(register/3 :: (atom(), binary(), atom()) -> 'ok').
+-spec(unregister/2 :: (atom(), binary()) -> 'ok').
+-spec(binary_to_type/1 ::
+        (binary()) -> atom() | rabbit_types:error('not_found')).
+-spec(lookup_module/2 ::
+        (atom(), atom()) -> rabbit_types:ok_or_error2(atom(), 'not_found')).
+-spec(lookup_all/1 :: (atom()) -> [{atom(), atom()}]).
+
+-endif.
+
+%%---------------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%---------------------------------------------------------------------------
+
+register(Class, TypeName, ModuleName) ->
+    gen_server:call(?SERVER, {register, Class, TypeName, ModuleName}, infinity).
+
+unregister(Class, TypeName) ->
+    gen_server:call(?SERVER, {unregister, Class, TypeName}, infinity).
+
+%% This is used with user-supplied arguments (e.g., on exchange
+%% declare), so we restrict it to existing atoms only.  This means it
+%% can throw a badarg, indicating that the type cannot have been
+%% registered.
+binary_to_type(TypeBin) when is_binary(TypeBin) ->
+    case catch list_to_existing_atom(binary_to_list(TypeBin)) of
+        {'EXIT', {badarg, _}} -> {error, not_found};
+        TypeAtom              -> TypeAtom
+    end.
+
+lookup_module(Class, T) when is_atom(T) ->
+    case ets:lookup(?ETS_NAME, {Class, T}) of
+        [{_, Module}] ->
+            {ok, Module};
+        [] ->
+            {error, not_found}
+    end.
+
+lookup_all(Class) ->
+    [{K, V} || [K, V] <- ets:match(?ETS_NAME, {{Class, '$1'}, '$2'})].
+
+%%---------------------------------------------------------------------------
+
+internal_binary_to_type(TypeBin) when is_binary(TypeBin) ->
+    list_to_atom(binary_to_list(TypeBin)).
+
+internal_register(Class, TypeName, ModuleName)
+  when is_atom(Class), is_binary(TypeName), is_atom(ModuleName) ->
+    ClassModule = class_module(Class),
+    Type        = internal_binary_to_type(TypeName),
+    RegArg      = {{Class, Type}, ModuleName},
+    ok = sanity_check_module(ClassModule, ModuleName),
+    true = ets:insert(?ETS_NAME, RegArg),
+    conditional_register(RegArg),
+    ok = ClassModule:added_to_rabbit_registry(Type, ModuleName),
+    ok.
+
+internal_unregister(Class, TypeName) ->
+    ClassModule = class_module(Class),
+    Type        = internal_binary_to_type(TypeName),
+    UnregArg    = {Class, Type},
+    conditional_unregister(UnregArg),
+    true = ets:delete(?ETS_NAME, UnregArg),
+    ok = ClassModule:removed_from_rabbit_registry(Type),
+    ok.
+
+%% register exchange decorator route callback only when implemented,
+%% in order to avoid unnecessary decorator calls on the fast
+%% publishing path
+conditional_register({{exchange_decorator, Type}, ModuleName}) ->
+    case erlang:function_exported(ModuleName, route, 2) of
+        true  -> true = ets:insert(?ETS_NAME,
+                                   {{exchange_decorator_route, Type},
+                                    ModuleName});
+        false -> ok
+    end;
+conditional_register(_) ->
+    ok.
+
+conditional_unregister({exchange_decorator, Type}) ->
+    true = ets:delete(?ETS_NAME, {exchange_decorator_route, Type}),
+    ok;
+conditional_unregister(_) ->
+    ok.
+
+sanity_check_module(ClassModule, Module) ->
+    case catch lists:member(ClassModule,
+                            lists:flatten(
+                              [Bs || {Attr, Bs} <-
+                                         Module:module_info(attributes),
+                                     Attr =:= behavior orelse
+                                         Attr =:= behaviour])) of
+        {'EXIT', {undef, _}}  -> {error, not_module};
+        false                 -> {error, {not_type, ClassModule}};
+        true                  -> ok
+    end.
+
+
+% Registry class modules. There should exist module for each registry class.
+% Class module should be behaviour (export behaviour_info/1) and implement
+% rabbit_registry_class behaviour itself: export added_to_rabbit_registry/2 
+% and removed_from_rabbit_registry/1 functions.
+class_module(exchange)            -> rabbit_exchange_type;
+class_module(auth_mechanism)      -> rabbit_auth_mechanism;
+class_module(runtime_parameter)   -> rabbit_runtime_parameter;
+class_module(exchange_decorator)  -> rabbit_exchange_decorator;
+class_module(queue_decorator)     -> rabbit_queue_decorator;
+class_module(policy_validator)    -> rabbit_policy_validator;
+class_module(ha_mode)             -> rabbit_mirror_queue_mode;
+class_module(channel_interceptor) -> rabbit_channel_interceptor;
+class_module(queue_master_locator)-> rabbit_queue_master_locator.
+
+%%---------------------------------------------------------------------------
+
+init([]) ->
+    ?ETS_NAME = ets:new(?ETS_NAME, [protected, set, named_table]),
+    {ok, none}.
+
+handle_call({register, Class, TypeName, ModuleName}, _From, State) ->
+    ok = internal_register(Class, TypeName, ModuleName),
+    {reply, ok, State};
+
+handle_call({unregister, Class, TypeName}, _From, State) ->
+    ok = internal_unregister(Class, TypeName),
+    {reply, ok, State};
+
+handle_call(Request, _From, State) ->
+    {stop, {unhandled_call, Request}, State}.
+
+handle_cast(Request, State) ->
+    {stop, {unhandled_cast, Request}, State}.
+
+handle_info(Message, State) ->
+    {stop, {unhandled_info, Message}, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/rabbit_registry_class.erl
+++ b/src/rabbit_registry_class.erl
@@ -1,0 +1,18 @@
+-module(rabbit_registry_class).
+
+-ifdef(use_specs).
+
+-callback added_to_rabbit_registry(atom(), atom()) -> ok.
+
+-callback removed_from_rabbit_registry(atom()) -> ok.
+
+-else.
+
+-export([behaviour_info/1]).
+
+behaviour_info(callbacks) ->
+    [{added_to_rabbit_registry, 2}, {removed_from_rabbit_registry, 1}];
+behaviour_info(_Other) ->
+    undefined.
+
+-endif.

--- a/src/rabbit_runtime_parameter.erl
+++ b/src/rabbit_runtime_parameter.erl
@@ -16,6 +16,10 @@
 
 -module(rabbit_runtime_parameter).
 
+-behaviour(rabbit_registry_class).
+
+-export([added_to_rabbit_registry/2, removed_from_rabbit_registry/1]).
+
 -ifdef(use_specs).
 
 -type(validate_results() ::
@@ -40,3 +44,6 @@ behaviour_info(_Other) ->
     undefined.
 
 -endif.
+
+added_to_rabbit_registry(_Type, _ModuleName) -> ok.
+removed_from_rabbit_registry(_Type) -> ok.


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/559
Callbacks to update interceptors.
Related to https://github.com/rabbitmq/rabbitmq-server/pull/578

Callback cause all channels to refresh interceptors list.