### PR TITLE
Prevent infinite loop on 'queue.declare'

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -413,10 +413,12 @@ not_found_or_absent_dirty(Name) ->
 with(Name, F, E) ->
     with(Name, F, E, 2000).
 
-with(Name, _F, E, 0) ->
-    E(not_found_or_absent_dirty(Name));
 with(Name, F, E, RetriesLeft) ->
     case lookup(Name) of
+        {ok, Q = #amqqueue{}} when RetriesLeft =:= 0 ->
+            %% Something bad happened to that queue, we are bailing out
+            %% on processing current request.
+            E({absent, Q, timeout});
         {ok, Q = #amqqueue{state = crashed}} ->
             E({absent, Q, crashed});
         {ok, Q = #amqqueue{pid = QPid}} ->

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -310,7 +310,11 @@ absent(#amqqueue{name = QueueName, pid = QPid, durable = true}, nodedown) ->
 
 absent(#amqqueue{name = QueueName}, crashed) ->
     protocol_error(not_found,
-                   "~s has crashed and failed to restart", [rs(QueueName)]).
+                   "~s has crashed and failed to restart", [rs(QueueName)]);
+
+absent(#amqqueue{name = QueueName}, timeout) ->
+    protocol_error(not_found,
+                   "failed to perform operation on ~s due to timeout", [rs(QueueName)]).
 
 type_class(byte)          -> int;
 type_class(short)         -> int;


### PR DESCRIPTION
`rabbit_channel:handle_method` for `queue.declare` could go into infinite loop, when it tries do define a queue which got somehow corrupted. This fix at least will help with symptoms of this corruption - channel will quickly become unstuck.

Loop happens due to somewhat special handling of `not_found` in 'queue.declare' - it is treated not as an error here, but as a permission to proceed with queue creation. As the base case of recursion in `rabbit_amqqueue:with/4` is actuallly about some unrecoverable error, it makes sense to always return `absent` error here. It will still result in `not_found` error for clients, but internally it'll be handled correctly.