### PR TITLE
Remove custom stderr formatting

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -655,18 +655,7 @@ format_many(List) ->
     lists:flatten([io_lib:format(F ++ "~n", A) || {F, A} <- List]).
 
 format_stderr(Fmt, Args) ->
-    case os:type() of
-        {unix, _} ->
-            Port = open_port({fd, 0, 2}, [out]),
-            port_command(Port, io_lib:format(Fmt, Args)),
-            port_close(Port);
-        {win32, _} ->
-            %% stderr on Windows is buffered and I can't figure out a
-            %% way to trigger a fflush(stderr) in Erlang. So rather
-            %% than risk losing output we write to stdout instead,
-            %% which appears to be unbuffered.
-            io:format(Fmt, Args)
-    end,
+    io:format(standard_error, Fmt, Args),
     ok.
 
 unfold(Fun, Init) ->


### PR DESCRIPTION
After testing it on windows/linux with R16B03 and 18.2 I beleive it can also be applied to `stable`.

Opening several ports for single fd is considered undefined behaviour in
erlang. It's safe to replace this whole function with `io:format`.

Because writing to standard_error with io:format is synchronous - after
this call has returned data was definitely sent to the port. And
`erlang:halt/` guarantees that this data will be flushed afterwards.

Closes #53 for `stable`