### PR TITLE
Adds channel_operation_timeout when channels notify queues of shutdown

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -159,6 +159,8 @@
 
 -define(EXCHANGE_DELETE_IN_PROGRESS_COMPONENT, <<"exchange-delete-in-progress">>).
 
+-define(CHANNEL_OPERATION_TIMEOUT, rabbit_misc:get_channel_operation_timeout()).
+
 %% Trying to send a term across a cluster larger than 2^31 bytes will
 %% cause the VM to exit with "Absurdly large distribution output data
 %% buffer". So we limit the max message size to 2^31 - 10^6 bytes (1MB

--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -31,7 +31,7 @@
 -export([consumers/1, consumers_all/1,  consumers_all/3, consumer_info_keys/0]).
 -export([basic_get/4, basic_consume/10, basic_cancel/4, notify_decorators/1]).
 -export([notify_sent/2, notify_sent_queue_down/1, resume/2]).
--export([notify_down_all/2, activate_limit_all/2, credit/5]).
+-export([notify_down_all/2, notify_down_all/3, activate_limit_all/2, credit/5]).
 -export([on_node_up/1, on_node_down/1]).
 -export([update/2, store_queue/1, update_decorators/1, policy_changed/2]).
 -export([start_mirroring/1, stop_mirroring/1, sync_mirrors/1,
@@ -160,6 +160,8 @@
 -spec(ack/3 :: (pid(), [msg_id()], pid()) -> 'ok').
 -spec(reject/4 :: (pid(), [msg_id()], boolean(), pid()) -> 'ok').
 -spec(notify_down_all/2 :: (qpids(), pid()) -> ok_or_errors()).
+-spec(notify_down_all/3 :: (qpids(), pid(), non_neg_integer())
+                           -> ok_or_errors()).
 -spec(activate_limit_all/2 :: (qpids(), pid()) -> ok_or_errors()).
 -spec(basic_get/4 :: (rabbit_types:amqqueue(), pid(), boolean(), pid()) ->
                           {'ok', non_neg_integer(), qmsg()} | 'empty').
@@ -687,13 +689,23 @@ reject(QPid, Requeue, MsgIds, ChPid) ->
     delegate:cast(QPid, {reject, Requeue, MsgIds, ChPid}).
 
 notify_down_all(QPids, ChPid) ->
-    {_, Bads} = delegate:call(QPids, {notify_down, ChPid}),
-    case lists:filter(
-           fun ({_Pid, {exit, {R, _}, _}}) -> rabbit_misc:is_abnormal_exit(R);
-               ({_Pid, _})                 -> false
-           end, Bads) of
-        []    -> ok;
-        Bads1 -> {error, Bads1}
+    notify_down_all(QPids, ChPid, ?CHANNEL_OPERATION_TIMEOUT).
+
+notify_down_all(QPids, ChPid, Timeout) ->
+    case rpc:call(node(), delegate, call,
+                  [QPids, {notify_down, ChPid}], Timeout) of
+        {badrpc, timeout} -> {error, {channel_operation_timeout, Timeout}};
+        {badrpc, Reason}  -> {error, Reason};
+        {_, Bads} ->
+            case lists:filter(
+                   fun ({_Pid, {exit, {R, _}, _}}) ->
+                           rabbit_misc:is_abnormal_exit(R);
+                       ({_Pid, _})                 -> false
+                   end, Bads) of
+                []    -> ok;
+                Bads1 -> {error, Bads1}
+            end;
+        Error         -> {error, Error}
     end.
 
 activate_limit_all(QPids, ChPid) ->

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -392,7 +392,7 @@ init([Channel, ReaderPid, WriterPid, ConnPid, ConnName, Protocol, User, VHost,
     rabbit_event:notify(channel_created, infos(?CREATION_EVENT_KEYS, State2)),
     rabbit_event:if_enabled(State2, #ch.stats_timer,
                             fun() -> emit_stats(State2) end),
-    put(channel_termination_timeout, ?CHANNEL_OPERATION_TIMEOUT),
+    put(channel_operation_timeout, ?CHANNEL_OPERATION_TIMEOUT),
     {ok, State2, hibernate,
      {backoff, ?HIBERNATE_AFTER_MIN, ?HIBERNATE_AFTER_MIN, ?DESIRED_HIBERNATE}}.
 
@@ -1772,7 +1772,7 @@ notify_queues(State = #ch{consumer_mapping  = Consumers,
     QPids = sets:to_list(
               sets:union(sets:from_list(consumer_queues(Consumers)), DQ)),
     {rabbit_amqqueue:notify_down_all(QPids, self(),
-                                     get(channel_termination_timeout)),
+                                     get(channel_operation_timeout)),
      State#ch{state = closing}}.
 
 foreach_per_queue(_F, []) ->

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -71,6 +71,7 @@
 -export([store_proc_name/1, store_proc_name/2]).
 -export([moving_average/4]).
 -export([get_env/3]).
+-export([get_channel_operation_timeout/0]).
 -export([random/1]).
 
 %% Horrible macro to use in guards
@@ -260,7 +261,7 @@
 -spec(moving_average/4 :: (float(), float(), float(), float() | 'undefined')
                           -> float()).
 -spec(get_env/3 :: (atom(), atom(), term())  -> term()).
-
+-spec(get_channel_operation_timeout/0 :: () -> non_neg_integer()).
 -spec(random/1 :: (non_neg_integer()) -> non_neg_integer()).
 
 -endif.
@@ -1117,6 +1118,13 @@ get_env(Application, Key, Def) ->
         {ok, Val} -> Val;
         undefined -> Def
     end.
+
+get_channel_operation_timeout() ->
+    %% Default channel_operation_timeout set to net_ticktime + 10s to
+    %% give allowance for any down messages to be received first,
+    %% whenever it is used for cross-node calls with timeouts.
+    Default = (net_kernel:get_net_ticktime() + 10) * 1000,
+    application:get_env(rabbit, channel_operation_timeout, Default).
 
 moving_average(_Time, _HalfLife, Next, undefined) ->
     Next;


### PR DESCRIPTION
Fixes rabbitmq/rabbitmq-server#248.