### PR TITLE
Add node health check

### DIFF
--- a/include/rabbit_misc.hrl
+++ b/include/rabbit_misc.hrl
@@ -1,0 +1,17 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-define(RPC_TIMEOUT, infinity).

--- a/src/rabbit_health_check.erl
+++ b/src/rabbit_health_check.erl
@@ -41,7 +41,7 @@ node_health_check(Node, is_running) ->
       fun(true) ->
               true;
          (false) ->
-              throw({node_is_ko, "rabbit application is not running"})
+              throw({node_is_ko, "rabbit application is not running", 70})
       end);
 node_health_check(Node, list_channels) ->
     node_health_check(
@@ -51,7 +51,7 @@ node_health_check(Node, list_channels) ->
          (Other) ->
               ErrorMsg = io_lib:format("list_channels unexpected output: ~p",
                                        [Other]),
-              throw({node_is_ko, ErrorMsg})
+              throw({node_is_ko, ErrorMsg, 70})
       end);
 node_health_check(Node, list_queues) ->
     node_health_check(
@@ -61,7 +61,7 @@ node_health_check(Node, list_queues) ->
          (Other) ->
               ErrorMsg = io_lib:format("list_queues unexpected output: ~p",
                                        [Other]),
-              throw({node_is_ko, ErrorMsg})
+              throw({node_is_ko, ErrorMsg, 70})
       end);
 node_health_check(Node, alarms) ->
     node_health_check(
@@ -72,7 +72,7 @@ node_health_check(Node, alarms) ->
                       true;
                   Alarms ->
                       ErrorMsg = io_lib:format("alarms raised ~p", [Alarms]),
-                      throw({node_is_ko, ErrorMsg})
+                      throw({node_is_ko, ErrorMsg, 70})
               end
       end).
 
@@ -82,11 +82,15 @@ node_health_check(Node, {M, F, A}, Fun) ->
             ErrorMsg = io_lib:format(
                          "health check of node ~p fails: timed out (~p ms)",
                          [Node, ?NODE_HEALTH_CHECK_TIMEOUT]),
-            throw({node_is_ko, ErrorMsg});
+            throw({node_is_ko, ErrorMsg, 70});
+        {badrpc, nodedown} ->
+            ErrorMsg = io_lib:format(
+                         "health check of node ~p fails: nodedown", [Node]),
+            throw({node_is_ko, ErrorMsg, 68});
         {badrpc, Reason} ->
             ErrorMsg = io_lib:format(
                          "health check of node ~p fails: ~p", [Node, Reason]),
-            throw({node_is_ko, ErrorMsg});
+            throw({node_is_ko, ErrorMsg, 70});
         Other ->
             Fun(Other)
     end.

--- a/src/rabbit_health_check.erl
+++ b/src/rabbit_health_check.erl
@@ -1,0 +1,94 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+-module(rabbit_health_check).
+
+-export([node/1]).
+
+-define(NODE_HEALTH_CHECK_TIMEOUT, 70000).
+
+-ifdef(use_specs).
+-spec(node/1 :: (node()) -> 'true' | no_return()).
+-endif.
+
+%%----------------------------------------------------------------------------
+%% External functions
+%%----------------------------------------------------------------------------
+node(Node) ->
+    node_health_check(Node, is_running),
+    node_health_check(Node, list_channels),
+    node_health_check(Node, list_queues),
+    node_health_check(Node, alarms).
+
+%%----------------------------------------------------------------------------
+%% Internal functions
+%%----------------------------------------------------------------------------
+node_health_check(Node, is_running) ->
+    node_health_check(
+      Node, {rabbit, is_running, []},
+      fun(true) ->
+              true;
+         (false) ->
+              throw({node_is_ko, "rabbit application is not running"})
+      end);
+node_health_check(Node, list_channels) ->
+    node_health_check(
+      Node, {rabbit_channel, info_all, [[pid]]},
+      fun(L) when is_list(L) ->
+              true;
+         (Other) ->
+              ErrorMsg = io_lib:format("list_channels unexpected output: ~p",
+                                       [Other]),
+              throw({node_is_ko, ErrorMsg})
+      end);
+node_health_check(Node, list_queues) ->
+    node_health_check(
+      Node, {rabbit_amqqueue, info_all, [[pid]]},
+      fun(L) when is_list(L) ->
+              true;
+         (Other) ->
+              ErrorMsg = io_lib:format("list_queues unexpected output: ~p",
+                                       [Other]),
+              throw({node_is_ko, ErrorMsg})
+      end);
+node_health_check(Node, alarms) ->
+    node_health_check(
+      Node, {rabbit, status, []},
+      fun(Props) ->
+              case proplists:get_value(alarms, Props) of
+                  [] ->
+                      true;
+                  Alarms ->
+                      ErrorMsg = io_lib:format("alarms raised ~p", [Alarms]),
+                      throw({node_is_ko, ErrorMsg})
+              end
+      end).
+
+node_health_check(Node, {M, F, A}, Fun) ->
+    case rabbit_misc:rpc_call(Node, M, F, A, ?NODE_HEALTH_CHECK_TIMEOUT) of
+        {badrpc, timeout} ->
+            ErrorMsg = io_lib:format(
+                         "health check of node ~p fails: timed out (~p ms)",
+                         [Node, ?NODE_HEALTH_CHECK_TIMEOUT]),
+            throw({node_is_ko, ErrorMsg});
+        {badrpc, Reason} ->
+            ErrorMsg = io_lib:format(
+                         "health check of node ~p fails: ~p", [Node, Reason]),
+            throw({node_is_ko, ErrorMsg});
+        Other ->
+            Fun(Other)
+    end.
+
+    

--- a/src/rabbit_health_check.erl
+++ b/src/rabbit_health_check.erl
@@ -71,7 +71,7 @@ node_health_check(Node, alarms) ->
                   [] ->
                       true;
                   Alarms ->
-                      ErrorMsg = io_lib:format("alarms raised ~p", [Alarms]),
+                      ErrorMsg = io_lib:format("resource alarm(s) in effect:~p", [Alarms]),
                       throw({node_is_ko, ErrorMsg, 70})
               end
       end).

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -17,6 +17,7 @@
 -module(rabbit_misc).
 -include("rabbit.hrl").
 -include("rabbit_framing.hrl").
+-include("rabbit_misc.hrl").
 
 -export([method_record_type/1, polite_pause/0, polite_pause/1]).
 -export([die/1, frame_error/2, amqp_error/4, quit/1,
@@ -73,6 +74,7 @@
 -export([get_env/3]).
 -export([get_channel_operation_timeout/0]).
 -export([random/1]).
+-export([rpc_call/4, rpc_call/5, rpc_call/7]).
 
 %% Horrible macro to use in guards
 -define(IS_BENIGN_EXIT(R),
@@ -263,6 +265,10 @@
 -spec(get_env/3 :: (atom(), atom(), term())  -> term()).
 -spec(get_channel_operation_timeout/0 :: () -> non_neg_integer()).
 -spec(random/1 :: (non_neg_integer()) -> non_neg_integer()).
+-spec(rpc_call/4 :: (node(), atom(), atom(), [any()]) -> any()).
+-spec(rpc_call/5 :: (node(), atom(), atom(), [any()], number()) -> any()).
+-spec(rpc_call/7 :: (node(), atom(), atom(), [any()], reference(), pid(),
+                     number()) -> any()).
 
 -endif.
 
@@ -1159,6 +1165,24 @@ random(N) ->
         _ -> ok
     end,
     random:uniform(N).
+
+%% Moved from rabbit/src/rabbit_cli.erl
+%% If the server we are talking to has non-standard net_ticktime, and
+%% our connection lasts a while, we could get disconnected because of
+%% a timeout unless we set our ticktime to be the same. So let's do
+%% that.
+rpc_call(Node, Mod, Fun, Args) ->
+    rpc_call(Node, Mod, Fun, Args, ?RPC_TIMEOUT).
+
+rpc_call(Node, Mod, Fun, Args, Timeout) ->
+    case rpc:call(Node, net_kernel, get_net_ticktime, [], Timeout) of
+        {badrpc, _} = E -> E;
+        Time            -> net_kernel:set_net_ticktime(Time, 0),
+                           rpc:call(Node, Mod, Fun, Args, Timeout)
+    end.
+
+rpc_call(Node, Mod, Fun, Args, Ref, Pid, Timeout) ->
+    rpc_call(Node, Mod, Fun, Args++[Ref, Pid], Timeout).
 
 %% -------------------------------------------------------------------------
 %% Begin copypasta from gen_server2.erl


### PR DESCRIPTION
Introduce node health check used by rabbitmqctl and the management HTTP API.

Moved `rabbit_cli:call_rpc` from the `rabbit` application to `rabbit_misc`, so it can be used by the health checks from `rabbit` and `rabbitmq_management` applications.

Part of https://github.com/rabbitmq/rabbitmq-server/issues/398