### PR TITLE
SPIKE rabbit_reader state machine(s) refactoring

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -151,11 +151,12 @@
   %% a set of the reasons why we are
   %% blocked: flow, resource
   block_reasons,
-  % map()
+  % a map of blocking reason => connection.blocked message
   block_messages,
-  %% boolean() true if received any publishes
+  %% true if received any publishes, false otherwise
   can_block,
-  % boolean()
+  %% true if we had we sent a connection.blocked,
+  %% false otherwise
   connection_blocked_message_sent
 }).
 

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -380,6 +380,7 @@ start_connection(Parent, HelperSup, Deb, Sock) ->
                 throttle            = #throttle{
                                          alarmed_by      = [],
                                          last_blocked_at = never,
+                                         have_publishes  = false,
                                          blocked_reasons = sets:new(),
                                          blocked_messages = maps:new(),
                                          connection_blocked_message_sent = false
@@ -1512,8 +1513,8 @@ update_last_blocked_at(Throttle) ->
 % blocked_by_queue(#throttle{blocked_reasons = Reasons}) ->
 %     sets:is_element(queue, Reasons).
 
-blocked_by_any(#throttle{blocked_reasons = []}) -> false;
-blocked_by_any(#throttle{}) -> true.
+blocked_by_any(#throttle{blocked_reasons = Reasons}) -> 
+    sets:size(Reasons) > 0.
 
 have_publishes(#throttle{have_publishes = HP}) -> HP.
 

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -148,7 +148,8 @@
   alarmed_by,
   %% never | timestamp()
   last_blocked_at,
-  % set()
+  %% a set of the reasons why we are
+  %% blocked: flow, resource
   block_reasons,
   % map()
   block_messages,

--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -1471,7 +1471,8 @@ send_error_on_channel0_and_close(Channel, Protocol, Reason, State) ->
 % Throttle specific functions:
 
 blocked_message(#throttle{blocked_messages = Msgs}) ->
-    rabbit_misc:json_encode(maps:to_list(Msgs)).
+    {ok, Msg} = rabbit_misc:json_encode(maps:to_list(Msgs)),
+    iolist_to_binary(Msg).
 
 update_alarms([], Throttle = #throttle{blocked_messages = Msgs, 
                                        blocked_reasons = Reasons}) ->


### PR DESCRIPTION
Idea to refactor blocking states in `rabbit_reader`
Currently there are `running` `blocking` and `blocked` states and `throttle` field, which contain state information. So transitions indirectly depend on this state information.

So proposal is to change this state machine: https://github.com/hairyhum/pics/blob/master/old.png
Into this: https://github.com/hairyhum/pics/blob/master/new.png

So there will be more sane transitions which will not depend so much on throttle values during transition.

See comments [here](https://github.com/rabbitmq/rabbitmq-server/issues/499#issuecomment-189233764) 