### PR TITLE
Updates queue_master_location/1 parameter spec from pid() to #amqqueue{}

### DIFF
--- a/src/rabbit_queue_master_locator.erl
+++ b/src/rabbit_queue_master_locator.erl
@@ -19,7 +19,8 @@
 -ifdef(use_specs).
 
 -callback description()                -> [proplists:property()].
--callback queue_master_location(pid()) -> {'ok', node()} | {'error', term()}.
+-callback queue_master_location(rabbit_types:amqqueue()) ->
+    {'ok', node()} | {'error', term()}.
 
 -else.
 


### PR DESCRIPTION
Fixes #68