### PR TITLE
Support for parallel info emission

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -25,10 +25,10 @@
          check_exclusive_access/2, with_exclusive_access_or_die/3,
          stat/1, deliver/2, requeue/3, ack/3, reject/4]).
 -export([list/0, list/1, info_keys/0, info/1, info/2, info_all/1, info_all/2,
-         info_all/6]).
+         emit_info_all/5, list_local/1]).
 -export([list_down/1]).
 -export([force_event_refresh/1, notify_policy_changed/1]).
--export([consumers/1, consumers_all/1,  consumers_all/3, consumer_info_keys/0]).
+-export([consumers/1, consumers_all/1,  emit_consumers_all/4, consumer_info_keys/0]).
 -export([basic_get/4, basic_consume/10, basic_cancel/4, notify_decorators/1]).
 -export([notify_sent/2, notify_sent_queue_down/1, resume/2]).
 -export([notify_down_all/2, notify_down_all/3, activate_limit_all/2, credit/5]).
@@ -39,7 +39,8 @@
 
 %% internal
 -export([internal_declare/2, internal_delete/1, run_backing_queue/3,
-         set_ram_duration_target/2, set_maximum_since_use/2]).
+         set_ram_duration_target/2, set_maximum_since_use/2,
+         emit_info_local/4, emit_info_down/4, emit_consumers_local/3]).
 
 -include("rabbit.hrl").
 -include_lib("stdlib/include/qlc.hrl").
@@ -625,16 +626,23 @@ info_all(VHostPath, Items) ->
     map(list(VHostPath), fun (Q) -> info(Q, Items) end) ++
         map(list_down(VHostPath), fun (Q) -> info_down(Q, Items, down) end).
 
-info_all(VHostPath, Items, NeedOnline, NeedOffline, Ref, AggregatorPid) ->
-    NeedOnline andalso rabbit_control_misc:emitting_map_with_exit_handler(
-                         AggregatorPid, Ref, fun(Q) -> info(Q, Items) end, list(VHostPath),
-                         continue),
-    NeedOffline andalso rabbit_control_misc:emitting_map_with_exit_handler(
-                          AggregatorPid, Ref, fun(Q) -> info_down(Q, Items, down) end,
-                          list_down(VHostPath),
-                          continue),
-    %% Previous maps are incomplete, finalize emission
-    rabbit_control_misc:emitting_map(AggregatorPid, Ref, fun(_) -> no_op end, []).
+emit_info_local(VHostPath, Items, Ref, AggregatorPid) ->
+    rabbit_control_misc:emitting_map_with_exit_handler(
+      AggregatorPid, Ref, fun(Q) -> info(Q, Items) end, list_local(VHostPath)).
+
+emit_info_all(Nodes, VHostPath, Items, Ref, AggregatorPid) ->
+    Pids = [ spawn_link(Node, rabbit_amqqueue, emit_info_local, [VHostPath, Items, Ref, AggregatorPid]) || Node <- Nodes ],
+    rabbit_control_misc:await_emitters_termination(Pids).
+
+emit_info_down(VHostPath, Items, Ref, AggregatorPid) ->
+    rabbit_control_misc:emitting_map_with_exit_handler(
+      AggregatorPid, Ref, fun(Q) -> info_down(Q, Items, down) end,
+      list_down(VHostPath)).
+
+list_local(VHostPath) ->
+    [ Q || #amqqueue{state = State, pid=QPid} = Q <- list(VHostPath),
+           State =/= crashed,
+           node() =:= node(QPid) ].
 
 force_event_refresh(Ref) ->
     [gen_server2:cast(Q#amqqueue.pid,
@@ -654,12 +662,17 @@ consumers_all(VHostPath) ->
       map(list(VHostPath),
           fun(Q) -> get_queue_consumer_info(Q, ConsumerInfoKeys) end)).
 
-consumers_all(VHostPath, Ref, AggregatorPid) ->
+emit_consumers_all(Nodes, VHostPath, Ref, AggregatorPid) ->
+    Pids = [ spawn_link(Node, rabbit_amqqueue, emit_consumers_local, [VHostPath, Ref, AggregatorPid]) || Node <- Nodes ],
+    rabbit_control_misc:await_emitters_termination(Pids),
+    ok.
+
+emit_consumers_local(VHostPath, Ref, AggregatorPid) ->
     ConsumerInfoKeys = consumer_info_keys(),
     rabbit_control_misc:emitting_map(
       AggregatorPid, Ref,
       fun(Q) -> get_queue_consumer_info(Q, ConsumerInfoKeys) end,
-      list(VHostPath)).
+      list_local(VHostPath)).
 
 get_queue_consumer_info(Q, ConsumerInfoKeys) ->
     [lists:zip(ConsumerInfoKeys,

--- a/src/rabbit_control_misc.erl
+++ b/src/rabbit_control_misc.erl
@@ -17,7 +17,8 @@
 -module(rabbit_control_misc).
 
 -export([emitting_map/4, emitting_map/5, emitting_map_with_exit_handler/4,
-         emitting_map_with_exit_handler/5, wait_for_info_messages/5,
+         emitting_map_with_exit_handler/5, wait_for_info_messages/6,
+         spawn_emitter_caller/7, await_emitters_termination/1,
          print_cmd_result/2]).
 
 -ifdef(use_specs).
@@ -27,7 +28,16 @@
 -spec(emitting_map_with_exit_handler/4 ::
         (pid(), reference(), fun(), list()) -> 'ok').
 -spec(emitting_map_with_exit_handler/5 ::
-        (pid(), reference(), fun(), list(), atom()) -> 'ok').
+        (pid(), reference(), fun(), list(), 'continue') -> 'ok').
+
+-type fold_fun() :: fun((Item, AccIn) -> AccOut) when
+      Item :: term(), AccIn :: term(), AccOut :: term().
+
+-spec(wait_for_info_messages/6 :: (pid(), reference(), fold_fun(), InitialAcc, timeout(), non_neg_integer()) -> OK | Err) when
+      InitialAcc :: term(), Acc :: term(), OK :: {ok, Acc}, Err :: {error, term()}.
+-spec(spawn_emitter_caller/7 :: (node(), module(), atom(), [term()], reference(), pid(), timeout()) -> 'ok').
+-spec(await_emitters_termination/1 :: ([pid()]) -> 'ok').
+
 -spec(print_cmd_result/2 :: (atom(), term()) -> 'ok').
 
 -endif.
@@ -69,27 +79,108 @@ step_with_exit_handler(AggregatorPid, Ref, Fun, Item) ->
             ok
     end.
 
-wait_for_info_messages(Pid, Ref, ArgAtoms, DisplayFun, Timeout) ->
-    _ = notify_if_timeout(Pid, Ref, Timeout),
-    wait_for_info_messages(Ref, ArgAtoms, DisplayFun).
+%% Invokes RPC for async info collection in separate (but linked to
+%% the caller) process. Separate process waits for RPC to finish and
+%% in case of errors sends them in wait_for_info_messages/5-compatible
+%% form to aggregator process. Calling process is then expected to
+%% do blocking call of wait_for_info_messages/5.
+%%
+%% Remote function MUST use calls to emitting_map/4 (and other
+%% emitting_map's) to properly deliver requested information to an
+%% aggregator process.
+%%
+%% If for performance reasons several parallel emitting_map's need to
+%% be run, remote function MUST NOT return until all this
+%% emitting_map's are done. And during all this time remote RPC
+%% process MUST be linked to emitting
+%% processes. await_emitters_termination/1 helper can be used as a
+%% last statement of remote function to ensure this behaviour.
+spawn_emitter_caller(Node, Mod, Fun, Args, Ref, Pid, Timeout) ->
+    spawn_monitor(
+      fun () ->
+              case rpc_call_emitter(Node, Mod, Fun, Args, Ref, Pid, Timeout) of
+                  {error, _} = Error        ->
+                      Pid ! {Ref, error, Error};
+                  {bad_argument, _} = Error ->
+                      Pid ! {Ref, error, Error};
+                  {badrpc, _} = Error       ->
+                      Pid ! {Ref, error, Error};
+                  _                         ->
+                      ok
+              end
+      end),
+    ok.
 
-wait_for_info_messages(Ref, InfoItemKeys, DisplayFun) when is_reference(Ref) ->
+rpc_call_emitter(Node, Mod, Fun, Args, Ref, Pid, Timeout) ->
+    rabbit_misc:rpc_call(Node, Mod, Fun, Args++[Ref, Pid], Timeout).
+
+%% Agregator process expects correct numbers of explicits ACKs about
+%% finished emission process. While everything is linked, we still
+%% need somehow to wait for termination of all emitters before
+%% returning from RPC call - otherwise links will be just broken with
+%% reason 'normal' and we can miss some errors, and subsequentially
+%% hang.
+await_emitters_termination(Pids) ->
+    Monitors = [erlang:monitor(process, Pid) || Pid <- Pids],
+    collect_monitors(Monitors).
+
+collect_monitors([]) ->
+    ok;
+collect_monitors([Monitor|Rest]) ->
     receive
-        {Ref,  finished}         ->
-            ok;
-        {Ref,  {timeout, T}}     ->
-            exit({error, {timeout, (T / 1000)}});
-        {Ref,  []}               ->
-            wait_for_info_messages(Ref, InfoItemKeys, DisplayFun);
-        {Ref,  Result, continue} ->
-            DisplayFun(Result, InfoItemKeys),
-            wait_for_info_messages(Ref, InfoItemKeys, DisplayFun);
-        {error, Error}           ->
-            Error;
-        _                        ->
-            wait_for_info_messages(Ref, InfoItemKeys, DisplayFun)
+        {'DOWN', Monitor, _Pid, normal} ->
+            collect_monitors(Rest);
+        {'DOWN', Monitor, _Pid, noproc} ->
+            %% There is a link and a monitor to a process. Matching
+            %% this clause means that process has gracefully
+            %% terminated even before we've started monitoring.
+            collect_monitors(Rest);
+        {'DOWN', _, Pid, Reason} ->
+            exit({emitter_exit, Pid, Reason})
     end.
 
+%% Wait for result of one or more calls to emitting_map-family
+%% functions.
+%%
+%% Number of expected acknowledgments is specified by ChunkCount
+%% argument. Most common usage will be with ChunkCount equals to
+%% number of live nodes, but it's not mandatory - thus more generic
+%% name of 'ChunkCount' was chosen.
+wait_for_info_messages(Pid, Ref, Fun, Acc0, Timeout, ChunkCount) ->
+    notify_if_timeout(Pid, Ref, Timeout),
+    wait_for_info_messages(Ref, Fun, Acc0, ChunkCount).
+
+wait_for_info_messages(Ref, Fun, Acc0, ChunksLeft) ->
+    receive
+        {Ref, finished} when ChunksLeft =:= 1 ->
+            {ok, Acc0};
+        {Ref, finished} ->
+            wait_for_info_messages(Ref, Fun, Acc0, ChunksLeft - 1);
+        {Ref, {timeout, T}} ->
+            exit({error, {timeout, (T / 1000)}});
+        {Ref, []} ->
+            wait_for_info_messages(Ref, Fun, Acc0, ChunksLeft);
+        {Ref, Result, continue} ->
+            wait_for_info_messages(Ref, Fun, Fun(Result, Acc0), ChunksLeft);
+        {Ref, error, Error} ->
+            {error, simplify_emission_error(Error)};
+        {'DOWN', _MRef, process, _Pid, normal} ->
+            wait_for_info_messages(Ref, Fun, Acc0, ChunksLeft);
+        {'DOWN', _MRef, process, _Pid, Reason} ->
+            {error, simplify_emission_error(Reason)};
+        _Msg ->
+            wait_for_info_messages(Ref, Fun, Acc0, ChunksLeft)
+    end.
+
+simplify_emission_error({badrpc, {'EXIT', {{nocatch, EmissionError}, _Stacktrace}}}) ->
+    EmissionError;
+simplify_emission_error({{nocatch, EmissionError}, _Stacktrace}) ->
+    EmissionError;
+simplify_emission_error(Anything) ->
+    {error, Anything}.
+
+notify_if_timeout(_, _, infinity) ->
+    ok;
 notify_if_timeout(Pid, Ref, Timeout) ->
     timer:send_after(Timeout, Pid, {Ref, {timeout, Timeout}}).
 

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -75,7 +75,7 @@
 -export([get_env/3]).
 -export([get_channel_operation_timeout/0]).
 -export([random/1]).
--export([rpc_call/4, rpc_call/5, rpc_call/7]).
+-export([rpc_call/4, rpc_call/5]).
 -export([report_default_thread_pool_size/0]).
 
 %% Horrible macro to use in guards
@@ -269,8 +269,6 @@
 -spec(random/1 :: (non_neg_integer()) -> non_neg_integer()).
 -spec(rpc_call/4 :: (node(), atom(), atom(), [any()]) -> any()).
 -spec(rpc_call/5 :: (node(), atom(), atom(), [any()], number()) -> any()).
--spec(rpc_call/7 :: (node(), atom(), atom(), [any()], reference(), pid(),
-                     number()) -> any()).
 -spec(report_default_thread_pool_size/0 :: () -> 'ok').
 
 -endif.
@@ -1187,9 +1185,6 @@ rpc_call(Node, Mod, Fun, Args, Timeout) ->
         Time            -> net_kernel:set_net_ticktime(Time, 0),
                            rpc:call(Node, Mod, Fun, Args, Timeout)
     end.
-
-rpc_call(Node, Mod, Fun, Args, Ref, Pid, Timeout) ->
-    rpc_call(Node, Mod, Fun, Args++[Ref, Pid], Timeout).
 
 guess_number_of_cpu_cores() ->
     case erlang:system_info(logical_processors_available) of


### PR DESCRIPTION
Complement for https://github.com/rabbitmq/rabbitmq-server/pull/683

- `rabbit_control_misc:wait_for_info_messages/5` can wait for results of
  more than one emitting map.
- Stop passing arround InfoItemKeys in
  `rabbit_control_misc:wait_for_info_messages/5`, the same information
  could be directly encoded in DisplayFun closure.
- Add `emit` to function names, to avoid confusion with regular ones
  which return result directly.