### PR TITLE
Add a special value to term_to_json to allow encoding empty JSON objects

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -1055,8 +1055,9 @@ json_to_term(V) when is_binary(V) orelse is_number(V) orelse V =:= null orelse
                      V =:= true orelse V =:= false ->
     V.
 
-%% This has the flaw that empty lists will never be JSON objects, so use with
-%% care.
+%% You can use the empty_struct value to represent empty JSON objects.
+term_to_json(empty_struct) ->
+    {struct, []};
 term_to_json([{_, _}|_] = L) ->
     {struct, [{K, term_to_json(V)} || {K, V} <- L]};
 term_to_json(L) when is_list(L) ->


### PR DESCRIPTION
Part of proposal to fix https://github.com/rabbitmq/rabbitmq-management/issues/75 on stable