### PR TITLE
Fix listing of down queues

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -629,7 +629,7 @@ info_all(VHostPath, Items, Ref, AggregatorPid) ->
       AggregatorPid, Ref, fun(Q) -> info(Q, Items) end, list(VHostPath),
       continue),
     rabbit_control_misc:emitting_map_with_exit_handler(
-      AggregatorPid, Ref, fun(Q) -> info_down(Q, Items) end,
+      AggregatorPid, Ref, fun(Q) -> info_down(Q, Items, down) end,
       list_down(VHostPath)).
 
 force_event_refresh(Ref) ->


### PR DESCRIPTION
`rabbit_amqqueue:info_down/2` was erroneously used insted of
`rabbit_amqqueue:info_down/3`.

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/696

And thanks to this issue it is now preemptively fixed in
https://github.com/rabbitmq/rabbitmq-server/pull/683 )