### PR TITLE
Fix `rabbitmqctl list_consumers`

### DIFF
--- a/src/rabbit_amqqueue.erl
+++ b/src/rabbit_amqqueue.erl
@@ -658,11 +658,10 @@ consumers_all(VHostPath, Ref, AggregatorPid) ->
       list(VHostPath)).
 
 get_queue_consumer_info(Q, ConsumerInfoKeys) ->
-    lists:flatten(
-      [lists:zip(ConsumerInfoKeys,
-                 [Q#amqqueue.name, ChPid, CTag,
-                  AckRequired, Prefetch, Args]) ||
-          {ChPid, CTag, AckRequired, Prefetch, Args} <- consumers(Q)]).
+    [lists:zip(ConsumerInfoKeys,
+               [Q#amqqueue.name, ChPid, CTag,
+                AckRequired, Prefetch, Args]) ||
+        {ChPid, CTag, AckRequired, Prefetch, Args} <- consumers(Q)].
 
 stat(#amqqueue{pid = QPid}) -> delegate:call(QPid, stat).
 


### PR DESCRIPTION
It makes no sense to concatenate information about several consumers
into single proplist.

`rabbit_amqqueue:consumers_all/1` is already doing `lists:append/1`, so
it is already capable of handling zero or more consumers reported.

And for `rabbitmqctl list_consumers` we need to support printing
lists-of-lists, for the same purpose of reporting zero or more consumers.

Another part for https://github.com/rabbitmq/rabbitmq-server/issues/701