### PR TITLE
Exclude vhost from authentication success events (see below)

### DIFF
--- a/src/rabbit_reader.erl
+++ b/src/rabbit_reader.erl
@@ -165,7 +165,7 @@
 -define(INFO_KEYS, ?CREATION_EVENT_KEYS ++ ?STATISTICS_KEYS -- [pid]).
 
 -define(AUTH_NOTIFICATION_INFO_KEYS,
-        [host, vhost, name, peer_host, peer_port, protocol, auth_mechanism,
+        [host, name, peer_host, peer_port, protocol, auth_mechanism,
          ssl, ssl_protocol, ssl_cipher, peer_cert_issuer, peer_cert_subject,
          peer_cert_validity]).
 


### PR DESCRIPTION
Authentication in AMQP 0-9-1 is a two step process:

 * Authentication
 * connection.open

Vhost is selected at the 2nd step, so in authentication success
events we don't have any information about the vhost. It is emitted,
however, as part of a "connection created" event immediately after.

Fixes https://github.com/rabbitmq/rabbitmq-event-exchange/issues/13.