### PR TITLE
Use IANA ephemeral port range for ipv6 checks

### DIFF
--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -50,7 +50,8 @@
 -include("rabbit.hrl").
 -include_lib("kernel/include/inet.hrl").
 
--define(FIRST_TEST_BIND_PORT, 10000).
+%% IANA-suggested ephemeral port range is 49152 to 65535
+-define(FIRST_TEST_BIND_PORT, 49152).
 
 %% POODLE
 -define(BAD_SSL_PROTOCOL_VERSIONS, [sslv3]).


### PR DESCRIPTION
Recent version of Windows, Linux and FreeBSD use this IANA range (or
its subset) - according to
https://en.wikipedia.org/wiki/Ephemeral_port

There are several reasons for this change:
- SELinux could prevent opening of non-ephemeral port without explicit
  declaration - that's why redhat package already does patching of
  this value.
- IPv6 testing process can interfere with startup of some legitimate
  app which doesn't expect that something else will be listening on
  that port. While it may sound as an unlikely event, crashes due to
  improper usage of ephemeral ports in other packages constantly
  happen on our CI systems.