### PR TITLE
Support otp style verify_fun ssl option

### DIFF
--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -188,33 +188,20 @@ fix_verify_fun(SslOptsConfig) ->
     %% Starting with ssl 4.0.1 in Erlang R14B, the verify_fun function
     %% takes 3 arguments and returns a tuple.
     {ok, SslAppVer} = application:get_key(ssl, vsn),
-    UseNewVerifyFun = rabbit_misc:version_compare(SslAppVer, "4.0.1", gte),
     case rabbit_misc:pget(verify_fun, SslOptsConfig) of
         {Module, Function, InitialUserState} ->
-            Fun = make_verify_fun(Module, Function, InitialUserState,
-                                  UseNewVerifyFun),
+            Fun = make_verify_fun(Module, Function, InitialUserState),
             rabbit_misc:pset(verify_fun, Fun, SslOptsConfig);
         {Module, Function} when is_atom(Module) ->
-            Fun = make_verify_fun(Module, Function, none,
-                                  UseNewVerifyFun),
+            Fun = make_verify_fun(Module, Function, none),
             rabbit_misc:pset(verify_fun, Fun, SslOptsConfig);
         {Verifyfun, _InitialUserState} when is_function(Verifyfun, 3) ->
             SslOptsConfig;
-        undefined when UseNewVerifyFun ->
-            SslOptsConfig;
         undefined ->
-            % unknown_ca errors are silently ignored prior to R14B unless we
-            % supply this verify_fun - remove when at least R14B is required
-            case proplists:get_value(verify, SslOptsConfig, verify_none) of
-                verify_none -> SslOptsConfig;
-                verify_peer -> [{verify_fun, fun([])    -> true;
-                                                ([_|_]) -> false
-                                             end}
-                                | SslOptsConfig]
-            end
+            SslOptsConfig
     end.
 
-make_verify_fun(Module, Function, InitialUserState, UseNewVerifyFun) ->
+make_verify_fun(Module, Function, InitialUserState) ->
     try
         %% Preload the module: it is required to use
         %% erlang:function_exported/3.
@@ -228,7 +215,7 @@ make_verify_fun(Module, Function, InitialUserState, UseNewVerifyFun) ->
     NewForm = erlang:function_exported(Module, Function, 3),
     OldForm = erlang:function_exported(Module, Function, 1),
     case {NewForm, OldForm} of
-        {true, _} when UseNewVerifyFun ->
+        {true, _} ->
             %% This verify_fun is supported by Erlang R14B+ (ssl
             %% 4.0.1 and later).
             Fun = fun(OtpCert, Event, UserState) ->
@@ -236,23 +223,16 @@ make_verify_fun(Module, Function, InitialUserState, UseNewVerifyFun) ->
             end,
             {Fun, InitialUserState};
         {_, true} ->
-            %% This verify_fun is supported by:
-            %%     o  Erlang up-to R13B;
-            %%     o  Erlang R14B+ for undocumented backward
-            %%        compatibility.
+            %% This verify_fun is supported by Erlang R14B+ for 
+            %% undocumented backward compatibility.
             %%
             %% InitialUserState is ignored in this case.
             fun(ErrorList) ->
                     Module:Function(ErrorList)
             end;
-        {_, false} when not UseNewVerifyFun ->
-            rabbit_log:error("SSL verify_fun: ~s:~s/1 form required "
-              "for Erlang R13B~n", [Module, Function]),
-            throw({error, {invalid_verify_fun, old_form_required}});
         _ ->
-            Arity = case UseNewVerifyFun of true -> 3; _ -> 1 end,
-            rabbit_log:error("SSL verify_fun: no ~s:~s/~b exported~n",
-              [Module, Function, Arity]),
+            rabbit_log:error("SSL verify_fun: no ~s:~s/3 exported~n",
+              [Module, Function]),
             throw({error, {invalid_verify_fun, function_not_exported}})
     end.
 

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -188,7 +188,6 @@ fix_ssl_options(Config) ->
 fix_verify_fun(SslOptsConfig) ->
     %% Starting with ssl 4.0.1 in Erlang R14B, the verify_fun function
     %% takes 3 arguments and returns a tuple.
-    {ok, SslAppVer} = application:get_key(ssl, vsn),
     case rabbit_misc:pget(verify_fun, SslOptsConfig) of
         {Module, Function, InitialUserState} ->
             Fun = make_verify_fun(Module, Function, InitialUserState),

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -227,8 +227,8 @@ make_verify_fun(Module, Function, InitialUserState) ->
             %% undocumented backward compatibility.
             %%
             %% InitialUserState is ignored in this case.
-            fun(ErrorList) ->
-                    Module:Function(ErrorList)
+            fun(Args) ->
+                    Module:Function(Args)
             end;
         _ ->
             rabbit_log:error("SSL verify_fun: no ~s:~s/3 exported~n",

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -194,10 +194,12 @@ fix_verify_fun(SslOptsConfig) ->
             Fun = make_verify_fun(Module, Function, InitialUserState,
                                   UseNewVerifyFun),
             rabbit_misc:pset(verify_fun, Fun, SslOptsConfig);
-        {Module, Function} ->
+        {Module, Function} when is_atom(Module) ->
             Fun = make_verify_fun(Module, Function, none,
                                   UseNewVerifyFun),
             rabbit_misc:pset(verify_fun, Fun, SslOptsConfig);
+        {Verifyfun, _InitialUserState} when is_function(Verifyfun, 3) ->
+            SslOptsConfig;
         undefined when UseNewVerifyFun ->
             SslOptsConfig;
         undefined ->

--- a/src/rabbit_networking.erl
+++ b/src/rabbit_networking.erl
@@ -74,9 +74,9 @@
 -type(protocol() :: atom()).
 -type(label() :: string()).
 
--spec(start_tcp_listener/1 :: (listener_config()) -> 'ok').
--spec(start_ssl_listener/2 ::
-        (listener_config(), rabbit_types:infos()) -> 'ok').
+-spec(start_tcp_listener/2 :: (listener_config(), integer()) -> 'ok').
+-spec(start_ssl_listener/3 ::
+        (listener_config(), rabbit_types:infos(), integer()) -> 'ok').
 -spec(stop_tcp_listener/1 :: (listener_config()) -> 'ok').
 -spec(active_listeners/0 :: () -> [rabbit_types:listener()]).
 -spec(node_listeners/1 :: (node()) -> [rabbit_types:listener()]).


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-trust-store/issues/14

Support `verify_fun` format like in [otp ssl](http://erlang.org/doc/man/ssl.html)

Removed old code, since we require R16B03.