### PR TITLE
Support for type-specific exchange info

### DIFF
--- a/src/rabbit_exchange_type.erl
+++ b/src/rabbit_exchange_type.erl
@@ -70,6 +70,11 @@
                                   rabbit_framing:amqp_table()) ->
     'ok' | rabbit_types:connection_exit().
 
+%% Exchange type specific info keys
+-callback info(rabbit_types:exchange()) -> [{atom(), term()}].
+
+-callback info(rabbit_types:exchange(), [atom()]) -> [{atom(), term()}].
+
 -else.
 
 -export([behaviour_info/1]).
@@ -78,7 +83,7 @@ behaviour_info(callbacks) ->
     [{description, 0}, {serialise_events, 0}, {route, 2},
      {validate, 1}, {validate_binding, 2}, {policy_changed, 2},
      {create, 2}, {delete, 3}, {add_binding, 3}, {remove_bindings, 3},
-     {assert_args_equivalence, 2}];
+     {assert_args_equivalence, 2}, {info, 1}, {info, 2}];
 behaviour_info(_Other) ->
     undefined.
 


### PR DESCRIPTION
Add new callbacks to `rabbit_exchange_type` behaviour to display type-specific exchange info.
Related to https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/pull/46
And https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/issues/3 issue.