### PR TITLE
Only set TEST_CONFIG_FILE if not set

### DIFF
--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -184,7 +184,7 @@ define test_rabbitmq_config_with_tls
 ].
 endef
 
-TEST_CONFIG_FILE = $(TEST_TMPDIR)/test.config
+TEST_CONFIG_FILE ?= $(TEST_TMPDIR)/test.config
 TEST_TLS_CERTS_DIR = $(TEST_TMPDIR)/tls-certs
 
 .PHONY: $(TEST_CONFIG_FILE)


### PR DESCRIPTION
I attempted to use the pattern used in the ``Makefile`` that is in multiple RabbitMQ repos for changing the config file without any success:

```Makefile
WITH_BROKER_TEST_MAKEVARS := \
	RABBITMQ_CONFIG_FILE=$(CURDIR)/etc/rabbit-test
```

This did not allow for ``make run-broker`` to execute successfully with my test configuration.

This change allows for the setting of ``TEST_CONFIG_FILE`` in the project ``Makefile`` without issue.

Perhaps my problem with the current pattern is user error, but I did not see the behavior of ``WITH_BROKER_TEST_MAKEVARS`` that would allow for the override of ``RABBITMQ_CONFIG_FILE`` to successfully work with ``make run-broker``.

My project's ``Makefile`` now reads as:

```Makefile
TEST_CONFIG_FILE=$(CURDIR)/etc/rabbit-test
```

and works as I would expect. This seems like it's not ideal or how the Makefile stuff is support to work, so if there's an alternative change that will get to allowing me to run my own config files for my tests and ``run-broker``, please let me know.

