### PR TITLE
Removed wrong included file.

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -16,7 +16,6 @@
 
 -module(rabbit_misc).
 -include("rabbit.hrl").
--include("rabbit_framing.hrl").
 -include("rabbit_misc.hrl").
 
 -export([method_record_type/1, polite_pause/0, polite_pause/1]).


### PR DESCRIPTION
- removed include of unavailable file **rabbit_framing.hrl** in **rabbit_misc.erl**

- Getting dependency error with rebar because of this.