### PR TITLE
Bounded OTP worker timeout

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -144,6 +144,8 @@
 -define(EMPTY_FRAME_SIZE, 8).
 
 -define(MAX_WAIT, 16#ffffffff).
+-define(SUPERVISOR_WAIT, infinity).
+-define(WORKER_WAIT, 30000).
 
 -define(HIBERNATE_AFTER_MIN,        1000).
 -define(DESIRED_HIBERNATE,         10000).

--- a/src/rabbit_heartbeat.erl
+++ b/src/rabbit_heartbeat.erl
@@ -116,7 +116,7 @@ start_heartbeater(TimeoutSec, SupPid, Sock, TimeoutFun, Name, Callback,
       SupPid, {Name,
                {rabbit_heartbeat, Callback,
                 [Sock, TimeoutSec, TimeoutFun, {Name, Identity}]},
-               transient, ?MAX_WAIT, worker, [rabbit_heartbeat]}).
+               transient, ?WORKER_WAIT, worker, [rabbit_heartbeat]}).
 
 heartbeater(Params, Identity) ->
     Deb = sys:debug_options([]),


### PR DESCRIPTION
Introduced new constants for worker and supervisor shutdown timeouts.
Set default worker timeout to 30 seconds.
Part of https://github.com/rabbitmq/rabbitmq-server/issues/541