### PR TITLE
Make `rabbit_health_check` completely node-local

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -56,7 +56,7 @@
 -export([send_command/2, deliver/4, deliver_reply/2,
          send_credit_reply/2, send_drained/2]).
 -export([list/0, info_keys/0, info/1, info/2, info_all/0, info_all/1,
-         info_all/3]).
+         info_all/3, info_local/1]).
 -export([refresh_config_local/0, ready_for_close/1]).
 -export([force_event_refresh/1]).
 
@@ -325,6 +325,9 @@ info_all() ->
 
 info_all(Items) ->
     rabbit_misc:filter_exit_map(fun (C) -> info(C, Items) end, list()).
+
+info_local(Items) ->
+    rabbit_misc:filter_exit_map(fun (C) -> info(C, Items) end, list_local()).
 
 info_all(Items, Ref, AggregatorPid) ->
     rabbit_control_misc:emitting_map_with_exit_handler(


### PR DESCRIPTION
Part of https://github.com/rabbitmq/rabbitmq-server/issues/818

Also:
- fix queues health-checking - `rabbit_amqqueue:info_all` was expecting
  vhost argument, but was passed `[pid]` instead. So no health check was
  actually performed. Proper way is to iterate over all vhosts.
- delegate all error/timeout handling to `rabbit_cli`, so no more magic
  `70` and `68` and no more `case`-ing on `badrpc` that is already
  present in other places.