### PR TITLE
Add web-stomp port generation to common test helpers

### DIFF
--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -94,9 +94,10 @@
     tcp_port_erlang_dist_proxy,
     tcp_port_mqtt,
     tcp_port_mqtt_tls,
+    tcp_port_web_mqtt,
     tcp_port_stomp,
     tcp_port_stomp_tls,
-    tcp_port_web_mqtt
+    tcp_port_web_stomp
   ]).
 
 %% -------------------------------------------------------------------
@@ -292,6 +293,10 @@ update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_mqtt_tls = Key | Rest]) ->
 update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_web_mqtt = Key | Rest]) ->
     NodeConfig1 = rabbit_ct_helpers:merge_app_env(NodeConfig,
       {rabbitmq_web_mqtt, [{tcp_config, [{port, ?config(Key, NodeConfig)}]}]}),
+    update_tcp_ports_in_rmq_config(NodeConfig1, Rest);
+update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_web_stomp = Key | Rest]) ->
+    NodeConfig1 = rabbit_ct_helpers:merge_app_env(NodeConfig,
+      {rabbitmq_web_stomp, [{tcp_config, [{port, ?config(Key, NodeConfig)}]}]}),
     update_tcp_ports_in_rmq_config(NodeConfig1, Rest);
 update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_stomp = Key | Rest]) ->
     NodeConfig1 = rabbit_ct_helpers:merge_app_env(NodeConfig,


### PR DESCRIPTION
Required for https://github.com/rabbitmq/rabbitmq-web-stomp/pull/63