### PR TITLE
Make `rand_compat:uniform/1` more uniform

### DIFF
--- a/src/rand_compat.erl
+++ b/src/rand_compat.erl
@@ -78,7 +78,19 @@ uniform() ->
     code_version:update(?MODULE),
     ?MODULE:uniform().
 
-uniform_pre_18()  -> random:uniform().
+ensure_random_seed() ->
+    case get(random_seed) of
+        undefined ->
+            random:seed(erlang:phash2([node()]),
+                        time_compat:monotonic_time(),
+                        time_compat:unique_integer());
+        _ -> ok
+    end.
+
+uniform_pre_18()  ->
+    ensure_random_seed(),
+    random:uniform().
+
 uniform_post_18() -> rand:uniform().
 
 %% uniform/1.
@@ -87,7 +99,10 @@ uniform(N) ->
     code_version:update(?MODULE),
     ?MODULE:uniform(N).
 
-uniform_pre_18(N)  -> random:uniform(N).
+uniform_pre_18(N)  ->
+    ensure_random_seed(),
+    random:uniform(N).
+
 uniform_post_18(N) -> rand:uniform(N).
 
 %% uniform_s/1.


### PR DESCRIPTION
`rand` automatically seeds implicit state generator with unique values,
but for `random` we need to do it manually. Corresponding code was lost
in 76f0dbb6.