### PR TITLE
Introduce rabbit_peer_discovery_backend

### DIFF
--- a/src/rabbit_peer_discovery_backend.erl
+++ b/src/rabbit_peer_discovery_backend.erl
@@ -28,7 +28,7 @@
 %%
 %% The Initial Developer of the Original Code is AWeber Communications.
 %% Copyright (c) 2014-2015 AWeber Communications
-%% Copyright (c) 2016-Current Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2016 Pivotal Software, Inc.  All rights reserved.
 %%
 
 -module(rabbit_peer_discovery_backend).

--- a/src/rabbit_peer_discovery_backend.erl
+++ b/src/rabbit_peer_discovery_backend.erl
@@ -1,0 +1,42 @@
+%% Copyright (c) 2014-2015 AWeber Communications
+%% All rights reserved.
+%%
+%% Redistribution and use in source and binary forms, with or without modification,
+%% are permitted provided that the following conditions are met:
+%%
+%%  * Redistributions of source code must retain the above copyright notice, this
+%%    list of conditions and the following disclaimer.
+%%  * Redistributions in binary form must reproduce the above copyright notice,
+%%    this list of conditions and the following disclaimer in the documentation
+%%    and/or other materials provided with the distribution.
+%%  * Neither the name of the rabbitmq-autocluster-consul plugin nor the names of its
+%%    contributors may be used to endorse or promote products derived from this
+%%    software without specific prior written permission.
+%%
+%% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+%% ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+%% WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+%% IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+%% INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+%% BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+%% DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+%% LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+%% OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+%% ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+%%
+%% The Original Code is rabbitmq-autocluster.
+%%
+%% The Initial Developer of the Original Code is AWeber Communications.
+%% Copyright (c) 2014-2015 AWeber Communications
+%% Copyright (c) 2016-Current Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_peer_discovery_backend).
+
+-include("rabbit.hrl").
+
+-callback list_nodes() -> {ok, Nodes :: list()}|{error, Reason :: string()}.
+
+-callback register() -> ok|{error, Reason :: string()}.
+
+-callback unregister() -> ok|{error, Reason :: string()}.

--- a/src/rabbit_peer_discovery_backend.erl
+++ b/src/rabbit_peer_discovery_backend.erl
@@ -35,8 +35,10 @@
 
 -include("rabbit.hrl").
 
--callback list_nodes() -> {ok, Nodes :: list()}|{error, Reason :: string()}.
+-callback list_nodes() -> {ok, Nodes :: list()} |
+                          {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} |
+                          {error, Reason :: string()}.
 
--callback register() -> ok|{error, Reason :: string()}.
+-callback register()   -> ok | {error, Reason :: string()}.
 
--callback unregister() -> ok|{error, Reason :: string()}.
+-callback unregister() -> ok | {error, Reason :: string()}.

--- a/src/rabbit_types.erl
+++ b/src/rabbit_types.erl
@@ -151,7 +151,7 @@
 
 -type(protocol_name() :: 'amqp0_8' | 'amqp0_9_1' | 'amqp1_0' | 'mqtt' | 'stomp' | any()).
 
--type(node_type() :: 'disc' | 'disk' | 'ram').
+-type(node_type() :: 'disc' | 'ram').
 
 -type(auth_user() ::
         #auth_user{username :: username(),

--- a/src/rabbit_types.erl
+++ b/src/rabbit_types.erl
@@ -30,7 +30,7 @@
               ok/1, error/1, ok_or_error/1, ok_or_error2/2, ok_pid_or_error/0,
               channel_exit/0, connection_exit/0, mfargs/0, proc_name/0,
               proc_type_and_name/0, timestamp/0,
-              tracked_connection/0]).
+              tracked_connection/0, node_type/0]).
 
 -type(maybe(T) :: T | 'none').
 -type(timestamp() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}).
@@ -150,6 +150,8 @@
 -type(protocol() :: rabbit_framing:protocol()).
 
 -type(protocol_name() :: 'amqp0_8' | 'amqp0_9_1' | 'amqp1_0' | 'mqtt' | 'stomp' | any()).
+
+-type(node_type() :: 'disc' | 'disk' | 'ram').
 
 -type(auth_user() ::
         #auth_user{username :: username(),


### PR DESCRIPTION
A new behaviour for pluggable cluster peer discovery.

Borrowed from [1] with a bit of renaming and a blessing from Gavin M. Roy.

1. https://github.com/aweber/rabbitmq-autocluster/blob/master/src/autocluster_backend.erl

Part of rabbitmq/rabbitmq-server/issues/486.