### PR TITLE
Rename mochinum, mochiweb_util and ec_semver modules

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,10 @@
 This package, the RabbitMQ commons library, is licensed under the MPL. For the
 MPL, please see LICENSE-MPL-RabbitMQ.
 
-The files 'ec_semver.erl' and 'ec_semver_parser.erl' are Copyright (c) 2011
+The files `rabbit_numerical.erl' and `rabbit_http_util.erl` are (c) 2007
+Mochi Media, Inc and licensed under a MIT license, see LICENSE-MIT-Mochi.
+
+The files 'rabbit_semver.erl' and 'rabbit_semver_parser.erl' are Copyright (c) 2011
 Erlware, LLC and licensed under a MIT license, see LICENSE-MIT-Erlware-Commons.
 
 If you have any questions regarding licensing, please contact us at

--- a/LICENSE-MIT-Mochi
+++ b/LICENSE-MIT-Mochi
@@ -1,0 +1,9 @@
+This is the MIT license.
+
+Copyright (c) 2007 Mochi Media, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/rabbit_http_util.erl
+++ b/src/rabbit_http_util.erl
@@ -3,7 +3,7 @@
 
 %% @doc Utilities for parsing and quoting.
 
--module(mochiweb_util).
+-module(rabbit_http_util).
 -author('bob@mochimedia.com').
 -export([join/2, quote_plus/1, urlencode/1, parse_qs/1, unquote/1]).
 -export([path_split/1]).
@@ -176,7 +176,7 @@ quote_plus(Int) when is_integer(Int) ->
 quote_plus(Binary) when is_binary(Binary) ->
     quote_plus(binary_to_list(Binary));
 quote_plus(Float) when is_float(Float) ->
-    quote_plus(mochinum:digits(Float));
+    quote_plus(rabbit_numerical:digits(Float));
 quote_plus(String) ->
     quote_plus(String, []).
 

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -730,11 +730,11 @@ compose_pid(Node, Cre, Id, Ser) ->
     <<131,NodeEnc/binary>> = term_to_binary(Node),
     binary_to_term(<<131,103,NodeEnc/binary,Id:32,Ser:32,Cre:8>>).
 
-version_compare(A, B, eq)  -> ec_semver:eql(A, B);
-version_compare(A, B, lt)  -> ec_semver:lt(A, B);
-version_compare(A, B, lte) -> ec_semver:lte(A, B);
-version_compare(A, B, gt)  -> ec_semver:gt(A, B);
-version_compare(A, B, gte) -> ec_semver:gte(A, B).
+version_compare(A, B, eq)  -> rabbit_semver:eql(A, B);
+version_compare(A, B, lt)  -> rabbit_semver:lt(A, B);
+version_compare(A, B, lte) -> rabbit_semver:lte(A, B);
+version_compare(A, B, gt)  -> rabbit_semver:gt(A, B);
+version_compare(A, B, gte) -> rabbit_semver:gte(A, B).
 
 version_compare(A, B) ->
     case version_compare(A, B, lt) of
@@ -752,8 +752,8 @@ version_compare(A, B) ->
 %% e.g. 3.6.6 is not compatible with 3.6.5
 %% This special case can be removed once 3.6.x reaches EOL
 version_minor_equivalent(A, B) ->
-    {{MajA, MinA, PatchA, _}, _} = ec_semver:normalize(ec_semver:parse(A)),
-    {{MajB, MinB, PatchB, _}, _} = ec_semver:normalize(ec_semver:parse(B)),
+    {{MajA, MinA, PatchA, _}, _} = rabbit_semver:normalize(rabbit_semver:parse(A)),
+    {{MajB, MinB, PatchB, _}, _} = rabbit_semver:normalize(rabbit_semver:parse(B)),
 
     case {MajA, MinA, MajB, MinB} of
         {3, 6, 3, 6} -> if

--- a/src/rabbit_numerical.erl
+++ b/src/rabbit_numerical.erl
@@ -13,7 +13,7 @@
 %% in Proceedings of the SIGPLAN '96 Conference on Programming Language
 %% Design and Implementation.
 
--module(mochinum).
+-module(rabbit_numerical).
 -author("Bob Ippolito <bob@mochimedia.com>").
 -export([digits/1, frexp/1, int_pow/2, int_ceil/1]).
 

--- a/src/rabbit_semver.erl
+++ b/src/rabbit_semver.erl
@@ -11,7 +11,7 @@
 %%%  See http://semver.org/ for the spec.
 %%% @end
 %%%-------------------------------------------------------------------
--module(ec_semver).
+-module(rabbit_semver).
 
 -export([parse/1,
          format/1,
@@ -24,7 +24,7 @@
          normalize/1,
          between/3]).
 
-%% For internal use by the ec_semver_parser peg
+%% For internal use by the rabbit_semver_parser peg
 -export([internal_parse_version/1]).
 
 -export_type([semver/0,
@@ -61,14 +61,14 @@
 %% @doc parse a string or binary into a valid semver representation
 -spec parse(any_version()) -> semver().
 parse(Version) when erlang:is_list(Version) ->
-    case ec_semver_parser:parse(Version) of
+    case rabbit_semver_parser:parse(Version) of
         {fail, _} ->
             {erlang:iolist_to_binary(Version), {[],[]}};
         Good ->
             Good
     end;
 parse(Version) when erlang:is_binary(Version) ->
-    case ec_semver_parser:parse(Version) of
+    case rabbit_semver_parser:parse(Version) of
         {fail, _} ->
             {Version, {[],[]}};
         Good ->

--- a/src/rabbit_semver_parser.erl
+++ b/src/rabbit_semver_parser.erl
@@ -1,7 +1,7 @@
 %%% Imported from https://github.com/erlware/erlware_commons.git
 %%% Commit 603441a0363d5433de2139759991c640846c3a62
 
--module(ec_semver_parser).
+-module(rabbit_semver_parser).
 -export([parse/1,file/1]).
 -define(p_anything,true).
 -define(p_charclass,true).
@@ -31,7 +31,7 @@ parse(Input) when is_binary(Input) ->
 
 -spec 'semver'(input(), index()) -> parse_result().
 'semver'(Input, Index) ->
-  p(Input, Index, 'semver', fun(I,D) -> (p_seq([fun 'major_minor_patch_min_patch'/2, p_optional(p_seq([p_string(<<"-">>), fun 'alpha_part'/2, p_zero_or_more(p_seq([p_string(<<".">>), fun 'alpha_part'/2]))])), p_optional(p_seq([p_string(<<"+">>), fun 'alpha_part'/2, p_zero_or_more(p_seq([p_string(<<".">>), fun 'alpha_part'/2]))])), p_not(p_anything())]))(I,D) end, fun(Node, _Idx) -> ec_semver:internal_parse_version(Node)  end).
+  p(Input, Index, 'semver', fun(I,D) -> (p_seq([fun 'major_minor_patch_min_patch'/2, p_optional(p_seq([p_string(<<"-">>), fun 'alpha_part'/2, p_zero_or_more(p_seq([p_string(<<".">>), fun 'alpha_part'/2]))])), p_optional(p_seq([p_string(<<"+">>), fun 'alpha_part'/2, p_zero_or_more(p_seq([p_string(<<".">>), fun 'alpha_part'/2]))])), p_not(p_anything())]))(I,D) end, fun(Node, _Idx) -> rabbit_semver:internal_parse_version(Node)  end).
 
 -spec 'major_minor_patch_min_patch'(input(), index()) -> parse_result().
 'major_minor_patch_min_patch'(Input, Index) ->

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -166,7 +166,7 @@ identifier_first_char() ->
     union([non_zero_digit(), uppercase(), lowercase()]).
 
 %% FIXME: We should have $- as a valid identifier_char(), but the
-%% ec_semver library doesn't support having a dash as the last
+%% rabbit_semver library doesn't support having a dash as the last
 %% character in an identifier. For now, do not use dashes in an
 %% identifier. We could probably fix the property to only generate dash
 %% as the non-first non-last character.


### PR DESCRIPTION
Part of https://github.com/rabbitmq/rabbitmq-common/issues/139

They are pulled by amqp_client and can create conflicts with
other libraries when developers build releases with the Rabbit
client and Mochiweb, for example.

* mochiweb_util -> rabbit_http_util
* mochinum -> rabbit_numerical
* ec_semver -> rabbit_semver