### PR TITLE
Add dependencies on compiler and syntax_tools

### DIFF
--- a/src/rabbit_common.app.src
+++ b/src/rabbit_common.app.src
@@ -9,6 +9,8 @@
 	{applications, [
 		kernel,
                 stdlib,
-                xmerl
+                xmerl,
+                syntax_tools,
+                compiler
 	]}
 ]}.


### PR DESCRIPTION
While they don't need to be started, we do depend on them,
so should list them as dependencies. This will ensure that
they will be included when building releases that include
the Erlang client.

Fixes https://github.com/rabbitmq/rabbitmq-erlang-client/issues/72.