### PR TITLE
Update Ranch and Cowboy

### DIFF
--- a/mk/rabbitmq-components.mk
+++ b/mk/rabbitmq-components.mk
@@ -79,7 +79,7 @@ dep_rabbitmq_public_umbrella          = git_rmq rabbitmq-public-umbrella $(curre
 # all projects use the same versions. It avoids conflicts and makes it
 # possible to work with rabbitmq-public-umbrella.
 
-dep_cowboy_commit = 1.0.3
+dep_cowboy_commit = 1.0.4
 dep_mochiweb = git git://github.com/basho/mochiweb.git v2.9.0p2
 dep_ranch_commit = 1.2.1
 dep_webmachine_commit = 1.10.8p2

--- a/mk/rabbitmq-components.mk
+++ b/mk/rabbitmq-components.mk
@@ -81,7 +81,7 @@ dep_rabbitmq_public_umbrella          = git_rmq rabbitmq-public-umbrella $(curre
 
 dep_cowboy_commit = 1.0.4
 dep_mochiweb = git git://github.com/basho/mochiweb.git v2.9.0p2
-dep_ranch_commit = 1.2.1
+dep_ranch_commit = 1.3.0
 dep_webmachine_commit = 1.10.8p2
 
 RABBITMQ_COMPONENTS = amqp_client \


### PR DESCRIPTION
The Ranch update is for SNI. See https://github.com/rabbitmq/rabbitmq-server/issues/789

The Cowboy update is because I noticed it was outdated for no good reasons (just one commit behind but since it's fixing a bug with Websocket we might as well use it).