### PR TITLE
Configurable shutdown timeouts

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -147,8 +147,10 @@
 -define(EMPTY_FRAME_SIZE, 8).
 
 -define(MAX_WAIT, 16#ffffffff).
--define(SUPERVISOR_WAIT, infinity).
--define(WORKER_WAIT, 30000).
+-define(SUPERVISOR_WAIT,
+        application:get_env(rabbit, supervisor_shutdown_timeout, infinity)).
+-define(WORKER_WAIT,
+        application:get_env(rabbit, worker_shutdown_timeout, 30000)).
 
 -define(HIBERNATE_AFTER_MIN,        1000).
 -define(DESIRED_HIBERNATE,         10000).

--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -148,9 +148,9 @@
 
 -define(MAX_WAIT, 16#ffffffff).
 -define(SUPERVISOR_WAIT,
-        application:get_env(rabbit, supervisor_shutdown_timeout, infinity)).
+        rabbit_misc:get_env(rabbit, supervisor_shutdown_timeout, infinity)).
 -define(WORKER_WAIT,
-        application:get_env(rabbit, worker_shutdown_timeout, 30000)).
+        rabbit_misc:get_env(rabbit, worker_shutdown_timeout, 30000)).
 
 -define(HIBERNATE_AFTER_MIN,        1000).
 -define(DESIRED_HIBERNATE,         10000).


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-server/issues/847

Loads shutdown timeout for supervisors and workers from application environment.
Can have impact on performance. Therefore needs to be perf-tested.