### PR TITLE
Change the message format

### DIFF
--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -660,7 +660,7 @@ send(Command, #ch{writer_pid = WriterPid}) ->
     ok = rabbit_writer:send_command(WriterPid, Command).
 
 format_soft_error(#amqp_error{name = N, explanation = E, method = M}) ->
-    io_lib:format("operation ~s caused a channel exception ~s: ~p", [M, N, E]);
+    io_lib:format("operation ~s caused a channel exception ~s: ~ts", [M, N, E]);
 format_soft_error(Reason) ->
     Reason.
 


### PR DESCRIPTION
Fixes:https://github.com/rabbitmq/rabbitmq-common/issues/162

to reproduce the problem:

```
curl -i -u guest:guest -H "content-type:application/json" \
  -XPUT -d'{"auto_delete":false,"durable":false,"arguments":{"x-queue-mode":"wrong"}}' \
  http://localhost:15672/api/queues/%2f/卓匃屟尢桨
```