### PR TITLE
mk/rabbitmq-components.mk: Switch to Cowboy 1.1.0

### DIFF
--- a/mk/rabbitmq-components.mk
+++ b/mk/rabbitmq-components.mk
@@ -100,7 +100,7 @@ dep_rabbitmq_public_umbrella          = git_rmq rabbitmq-public-umbrella $(curre
 # all projects use the same versions. It avoids conflicts and makes it
 # possible to work with rabbitmq-public-umbrella.
 
-dep_cowboy_commit = 1.0.4
+dep_cowboy_commit = 1.1.0
 dep_mochiweb = git git://github.com/basho/mochiweb.git v2.9.0p2
 dep_ranch_commit = 1.3.1
 dep_webmachine_commit = 1.10.8p2


### PR DESCRIPTION
The new feature of Cowboy 1.1.0 of interest to RabbitMQ is the possibility to serve static files from Erlang application .ez archives. This will allow us to get rid of the plugins expansion during RabbitMQ
startup.

Cowboy 1.1.0 also comes with a stricter URL parser. In particular, `+` characters are not converted to spaces anymore! They are left alone. Users of the HTTP API must make sure that their requests are encoded using path segment encoding, not query string encoding (where `+` are converted to spaces).

References ninenines/cowboy#1070.
References ninenines/cowboy#1080.
[#136779967]