### PR TITLE
Initialise stats-related functions in enter_loop

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -514,10 +514,14 @@ enter_loop(Mod, Options, State, ServerName, Timeout, Backoff) ->
     Debug = debug_options(Name, Options),
     Queue = priority_queue:new(),
     Backoff1 = extend_backoff(Backoff),
+    {InitStatsFun, EmitStatsFun, StopStatsFun} = stats_funs(),
     loop(find_prioritisers(
            #gs2_state { parent = Parent, name = Name, state = State,
                         mod = Mod, time = Timeout, timeout_state = Backoff1,
-                        queue = Queue, debug = Debug })).
+                        queue = Queue, debug = Debug, 
+                        init_stats_fun = InitStatsFun,
+                        emit_stats_fun = EmitStatsFun,
+                        stop_stats_fun = StopStatsFun })).
 
 %%%========================================================================
 %%% Gen-callback functions


### PR DESCRIPTION
CRASH REPORT Process <0.1633.0> with 0 neighbours crashed with reason: bad function undefined in gen_server2:terminate/3 line 1138