### PR TITLE
Restore "rabbitmq-run.mk: Remove $RABBITMQ_PLUGINS_EXPAND_DIR"

### DIFF
--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -65,7 +65,6 @@ node_log_base = $(call node_tmpdir,$(1))/log
 node_mnesia_base = $(call node_tmpdir,$(1))/mnesia
 node_mnesia_dir = $(call node_mnesia_base,$(1))/$(1)
 node_schema_dir = $(call node_tmpdir,$(1))/schema
-node_plugins_expand_dir = $(call node_tmpdir,$(1))/plugins
 node_generated_config_dir = $(call node_tmpdir,$(1))/config
 node_enabled_plugins_file = $(call node_tmpdir,$(1))/enabled_plugins
 
@@ -79,7 +78,6 @@ RABBITMQ_LOG_BASE ?= $(call node_log_base,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_MNESIA_BASE ?= $(call node_mnesia_base,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_MNESIA_DIR ?= $(call node_mnesia_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_SCHEMA_DIR ?= $(call node_schema_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
-RABBITMQ_PLUGINS_EXPAND_DIR ?= $(call node_plugins_expand_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_GENERATED_CONFIG_DIR ?= $(call node_generated_config_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_ENABLED_PLUGINS_FILE ?= $(call node_enabled_plugins_file,$(RABBITMQ_NODENAME_FOR_PATHS))
 
@@ -102,7 +100,6 @@ RABBITMQ_MNESIA_DIR="$(call node_mnesia_dir,$(2))" \
 RABBITMQ_SCHEMA_DIR="$(call node_schema_dir,$(2))" \
 RABBITMQ_GENERATED_CONFIG_DIR="$(call node_generated_config_dir,$(2))" \
 RABBITMQ_PLUGINS_DIR="$(CURDIR)/$(DIST_DIR)" \
-RABBITMQ_PLUGINS_EXPAND_DIR="$(call node_plugins_expand_dir,$(2))" \
 RABBITMQ_SERVER_START_ARGS="$(RABBITMQ_SERVER_START_ARGS)"
 endef
 
@@ -124,7 +121,6 @@ node-tmpdir:
 	$(verbose) mkdir -p $(RABBITMQ_LOG_BASE) \
 		$(RABBITMQ_MNESIA_BASE) \
 		$(RABBITMQ_SCHEMA_DIR) \
-		$(RABBITMQ_PLUGINS_EXPAND_DIR) \
 		$(RABBITMQ_GENERATED_CONFIG_DIR)
 
 virgin-node-tmpdir:
@@ -132,7 +128,6 @@ virgin-node-tmpdir:
 	$(verbose) mkdir -p $(RABBITMQ_LOG_BASE) \
 		$(RABBITMQ_MNESIA_BASE) \
 		$(RABBITMQ_SCHEMA_DIR) \
-		$(RABBITMQ_PLUGINS_EXPAND_DIR) \
 		$(RABBITMQ_GENERATED_CONFIG_DIR)
 
 .PHONY: test-tmpdir virgin-test-tmpdir node-tmpdir virgin-node-tmpdir


### PR DESCRIPTION
Support for reading static files from Erlang .ez archives was added to Cowboy and various RabbitMQ plugins were updated to take advantage of the new API.

So this commit restores commit 59cd2ca5e48c1a011a0ae18392d20272215a3783.

It was reverted in 5079a36e0612f8739eb17149d6ae17c002396c74 because Cowboy didn't have this support at the time.

Signed-off-by: Gerhard Lazu <gerhard@rabbitmq.com>

[#118562759, #136622317]