### PR TITLE
Better error handling for module attributes

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -799,15 +799,13 @@ gb_trees_foreach(Fun, Tree) ->
     gb_trees_fold(fun (Key, Val, Acc) -> Fun(Key, Val), Acc end, ok, Tree).
 
 module_attributes(Module) ->
-    case catch Module:module_info(attributes) of
-        {'EXIT', {undef, [{Module, module_info, _} | _]}} ->
+    try
+        Module:module_info(attributes)
+    catch
+        _:undef ->
             io:format("WARNING: module ~p not found, so not scanned for boot steps.~n",
                       [Module]),
-            [];
-        {'EXIT', Reason} ->
-            exit(Reason);
-        V ->
-            V
+            []
     end.
 
 all_module_attributes(Name) ->


### PR DESCRIPTION
Stacktrace elements can also be a 4-element tuples like
`{module,function,[attributes],[]}`

But as we only care about an `undef` error fact, it makes no sense
to inspect stacktrace contents.