### PR TITLE
Log every stopping application

### DIFF
--- a/src/app_utils.erl
+++ b/src/app_utils.erl
@@ -58,7 +58,10 @@ start_applications(Apps, ErrorHandler) ->
 
 stop_applications(Apps, ErrorHandler) ->
     manage_applications(fun lists:foldr/3,
-                        fun application:stop/1,
+                        fun(App) ->
+                            rabbit_log:info("Stopping application: ~p", [App]),
+                            application:stop(App)
+                        end,
                         fun application:start/1,
                         not_started,
                         ErrorHandler,

--- a/src/app_utils.erl
+++ b/src/app_utils.erl
@@ -59,7 +59,7 @@ start_applications(Apps, ErrorHandler) ->
 stop_applications(Apps, ErrorHandler) ->
     manage_applications(fun lists:foldr/3,
                         fun(App) ->
-                            rabbit_log:info("Stopping application: ~p", [App]),
+                            rabbit_log:info("Stopping application '~s'", [App]),
                             application:stop(App)
                         end,
                         fun application:start/1,


### PR DESCRIPTION
Part of https://github.com/rabbitmq/rabbitmq-server/pull/1141
Addresses rabbitmq/rabbitmq-server#1122

When RabbitMQ server is stopping it stops all plugin applications.
If an application fails to stop - it can make entire erlang node
unresponsive.
Log will clarify which application is stopping at a moment.