### PR TITLE
Allow building plugins written in Elixir

### DIFF
--- a/mk/rabbitmq-dist.mk
+++ b/mk/rabbitmq-dist.mk
@@ -31,7 +31,7 @@ endef
 define get_mix_project_version
 $(shell cd $(1) && \
 	$(MIX) do deps.get, deps.compile, compile >/dev/null && \
-	$(MIX) run -e "IO.puts(Mix.Project.config[:version])")
+	$(MIX) run --no-start -e "IO.puts(Mix.Project.config[:version])")
 endef
 
 # Define the target to create an .ez plugin archive for an


### PR DESCRIPTION
One of the thing RabbitMQ expects from a plugin is a dependency on the
`rabbit` app. The problem is that `mix run` tries to start plugin app,
which leads to an unsuccessful attempt to start `rabbit` app.