### PR TITLE
Regenerate Elixir-based .ez-s after changes

### DIFF
--- a/mk/rabbitmq-dist.mk
+++ b/mk/rabbitmq-dist.mk
@@ -89,6 +89,8 @@ $$(dist_$(1)_ez): VSN     = $(2)
 $$(dist_$(1)_ez): SRC_DIR = $(3)
 $$(dist_$(1)_ez): EZ_DIR  = $$(abspath $$(dist_$(1)_ez_dir))
 $$(dist_$(1)_ez): EZ      = $$(dist_$(1)_ez)
+$$(dist_$(1)_ez): $$(if $$(wildcard _build/dev/lib/$(1)/ebin $(3)/priv),\
+	$$(call core_find,$$(wildcard _build/dev/lib/$(1)/ebin $(3)/priv),*),)
 
 MIX_DIST_EZS += $$(dist_$(1)_ez)
 EXTRA_DIST_EZS += $$(call get_mix_project_dep_ezs,$(3))


### PR DESCRIPTION
After changing any .erl-file and running `make dist` .ez files are
regenerated. But this is not the case for Elixir plugins - so it's
necessary to clean `plugins/` to refresh.

The difference is that for erlang.mk projects there is an explicit
dependencies on `ebin`, `include` and `priv` folder content -
https://github.com/rabbitmq/rabbitmq-common/blob/adaa9ac03943055ad68017df3b4272e8bf93bc3a/mk/rabbitmq-dist.mk#L52

But there were no similar rule around
https://github.com/rabbitmq/rabbitmq-common/blob/adaa9ac03943055ad68017df3b4272e8bf93bc3a/mk/rabbitmq-dist.mk#L91

So I've tried to add some reasonable dependencies there. I'm not so sure about `_build/dev/...` choice, but at least it works.