### PR TITLE
Make rabbit application transient

### DIFF
--- a/src/app_utils.erl
+++ b/src/app_utils.erl
@@ -50,7 +50,7 @@ stop_applications(Apps) ->
 
 start_applications(Apps, ErrorHandler) ->
     manage_applications(fun lists:foldl/3,
-                        fun application:start/1,
+                        fun start/1,
                         fun application:stop/1,
                         already_started,
                         ErrorHandler,
@@ -62,7 +62,7 @@ stop_applications(Apps, ErrorHandler) ->
                             rabbit_log:info("Stopping application '~s'", [App]),
                             application:stop(App)
                         end,
-                        fun application:start/1,
+                        fun start/1,
                         not_started,
                         ErrorHandler,
                         Apps).
@@ -124,3 +124,9 @@ manage_applications(Iterate, Do, Undo, SkipError, ErrorHandler, Apps) ->
             end, [], Apps),
     ok.
 
+start(rabbit) ->
+    %% Stops the Erlang VM when the rabbit application stops abnormally
+    %% i.e. message store reaches its restart limit
+    application:start(rabbit, transient);
+start(App) ->
+    application:start(App).

--- a/src/supervisor2.erl
+++ b/src/supervisor2.erl
@@ -142,13 +142,7 @@
            [ChildSpec :: child_spec()]}}
     | ignore.
 
-%% Optional callback prep_stop/0. It cannot be exported as Erlang/OTP doesn't
-%% support definition of optional callbacks.
-%%
-%% Currently used to stop application dependencies.
-%%
-%% -callback prep_stop() -> ok.
-%%
+-callback prep_stop() -> ok.
 
 -define(restarting(_Pid_), {restarting,_Pid_}).
 


### PR DESCRIPTION
Reverts the implementation of `supervisor2:prep_stop` as it is not necessary anymore with the VM shutdown. 

Part of https://github.com/rabbitmq/rabbitmq-server/issues/1216