### PR TITLE
Expand username & vhost variables in topic perms

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -268,8 +268,6 @@
 
 -define(CHANNEL_OPERATION_TIMEOUT, rabbit_misc:get_channel_operation_timeout()).
 
--define(TIMEOUT_60s, 60000).
-
 %% Trying to send a term across a cluster larger than 2^31 bytes will
 %% cause the VM to exit with "Absurdly large distribution output data
 %% buffer". So we limit the max message size to 2^31 - 10^6 bytes (1MB

--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -268,6 +268,8 @@
 
 -define(CHANNEL_OPERATION_TIMEOUT, rabbit_misc:get_channel_operation_timeout()).
 
+-define(TIMEOUT_60s, 60000).
+
 %% Trying to send a term across a cluster larger than 2^31 bytes will
 %% cause the VM to exit with "Absurdly large distribution output data
 %% buffer". So we limit the max message size to 2^31 - 10^6 bytes (1MB

--- a/src/rabbit_amqp_connection.erl
+++ b/src/rabbit_amqp_connection.erl
@@ -1,0 +1,23 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(rabbit_amqp_connection).
+
+-export([amqp_params/2]).
+
+-spec amqp_params(pid(), timeout()) -> [{atom(), term()}].
+amqp_params(ConnPid, Timeout) ->
+    gen_server:call(ConnPid, {info, [amqp_params]}, Timeout).

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -183,7 +183,7 @@ check_topic_access(#auth_user{username = Username},
                          end,
             PermRegexpExpanded = expand_topic_permission(
                 PermRegexp,
-                maps:get(expand_map, Context, undefined)
+                maps:get(variable_map, Context, undefined)
             ),
             case re:run(maps:get(routing_key, Context), PermRegexpExpanded, [{capture, none}]) of
                 match    -> true;

--- a/src/rabbit_auth_backend_internal.erl
+++ b/src/rabbit_auth_backend_internal.erl
@@ -41,7 +41,7 @@
          list_user_topic_permissions/1, list_vhost_topic_permissions/1, list_user_vhost_topic_permissions/2]).
 
 %% for testing
--export([hashing_module_for_user/1]).
+-export([hashing_module_for_user/1, expand_topic_permission/2]).
 
 %%----------------------------------------------------------------------------
 
@@ -181,12 +181,26 @@ check_topic_access(#auth_user{username = Username},
                              <<"">> -> <<$^, $$>>;
                              RE     -> RE
                          end,
-            case re:run(maps:get(routing_key, Context), PermRegexp, [{capture, none}]) of
+            PermRegexpExpanded = expand_topic_permission(
+                PermRegexp,
+                maps:get(expand_map, Context, undefined)
+            ),
+            case re:run(maps:get(routing_key, Context), PermRegexpExpanded, [{capture, none}]) of
                 match    -> true;
                 nomatch  -> false
             end
     end.
 
+expand_topic_permission(Permission, ToExpand) when is_map(ToExpand) ->
+    Opening = <<"{">>,
+    Closing = <<"}">>,
+    ReplaceFun = fun(K, V, Acc) ->
+                    Placeholder = <<Opening/binary, K/binary, Closing/binary>>,
+                    binary:replace(Acc, Placeholder, V, [global])
+                 end,
+    maps:fold(ReplaceFun, Permission, ToExpand);
+expand_topic_permission(Permission, _ToExpand) ->
+    Permission.
 
 permission_index(configure) -> #permission.configure;
 permission_index(write)     -> #permission.write;

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -797,9 +797,8 @@ check_topic_authorisation(#exchange{name = Name = #resource{virtual_host = VHost
                           RoutingKey,
                           Permission) ->
     Resource = Name#resource{kind = topic},
-    VariableMap = build_topic_variable_map(
-        amqp_connection:info(ConnPid, [amqp_params]),
-        VHost, Username),
+    AmqpConnInfo = gen_server:call(ConnPid, {info, [amqp_params]}, ?TIMEOUT_60s),
+    VariableMap = build_topic_variable_map(AmqpConnInfo, VHost, Username),
     Context = #{routing_key   => RoutingKey,
                 variable_map  => VariableMap
     },

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -67,6 +67,8 @@
 %% Internal
 -export([list_local/0, emit_info_local/3, deliver_reply_local/3]).
 -export([get_vhost/1, get_user/1]).
+%% For testing
+-export([build_topic_variable_map/3]).
 
 -record(ch, {
   %% starting | running | flow | closing
@@ -373,6 +375,7 @@ init([Channel, ReaderPid, WriterPid, ConnPid, ConnName, Protocol, User, VHost,
              true   -> flow;
              false  -> noflow
            end,
+
     State = #ch{state                   = starting,
                 protocol                = Protocol,
                 channel                 = Channel,
@@ -790,15 +793,15 @@ check_internal_exchange(_) ->
     ok.
 
 check_topic_authorisation(#exchange{name = Name = #resource{virtual_host = VHost}, type = topic},
-                          #ch{user = User = #user{username = Username}},
+                          #ch{user = User = #user{username = Username}, conn_pid = ConnPid},
                           RoutingKey,
                           Permission) ->
     Resource = Name#resource{kind = topic},
+    VariableMap = build_topic_variable_map(
+        amqp_connection:info(ConnPid, [amqp_params]),
+        VHost, Username),
     Context = #{routing_key   => RoutingKey,
-                variable_map  => #{
-                    <<"username">> => Username,
-                    <<"vhost">>    => VHost
-                }
+                variable_map  => VariableMap
     },
     Cache = case get(topic_permission_cache) of
                 undefined -> [];
@@ -813,6 +816,19 @@ check_topic_authorisation(#exchange{name = Name = #resource{virtual_host = VHost
     end;
 check_topic_authorisation(_, _, _, _) ->
     ok.
+
+build_topic_variable_map(AmqpParams, VHost, Username) ->
+    VariableFromAmqpParams = extract_topic_variable_map_from_amqp_params(AmqpParams),
+    maps:merge(VariableFromAmqpParams, #{<<"vhost">> => VHost, <<"username">> => Username}).
+
+%% use tuple representation of amqp_params to avoid coupling.
+%% get variable map only from amqp_params_direct, not amqp_params_network.
+%% amqp_params_direct are usually used from plugins (e.g. MQTT, STOMP)
+extract_topic_variable_map_from_amqp_params([{amqp_params, {amqp_params_direct, _, _, _, _,
+                                             {amqp_adapter_info, _,_,_,_,_,_,AdditionalInfo}, _}}]) ->
+    proplists:get_value(variable_map, AdditionalInfo, #{});
+extract_topic_variable_map_from_amqp_params(_) ->
+    #{}.
 
 check_msg_size(Content) ->
     Size = rabbit_basic:maybe_gc_large_msg(Content),

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -789,13 +789,13 @@ check_internal_exchange(#exchange{name = Name, internal = true}) ->
 check_internal_exchange(_) ->
     ok.
 
-check_topic_authorisation(#exchange{name = Name, type = topic}, #ch{user = User}, RoutingKey, Permission) ->
+check_topic_authorisation(#exchange{name = Name = #resource{virtual_host = VHost}, type = topic},
+                          #ch{user = User = #user{username = Username}},
+                          RoutingKey,
+                          Permission) ->
     Resource = Name#resource{kind = topic},
-    #user{username = Username} = User,
-    #resource{virtual_host = VHost} = Resource,
-
-    Context = #{routing_key => RoutingKey,
-                expand_map  => #{
+    Context = #{routing_key   => RoutingKey,
+                variable_map  => #{
                     <<"username">> => Username,
                     <<"vhost">>    => VHost
                 }

--- a/src/rabbit_channel.erl
+++ b/src/rabbit_channel.erl
@@ -791,7 +791,15 @@ check_internal_exchange(_) ->
 
 check_topic_authorisation(#exchange{name = Name, type = topic}, #ch{user = User}, RoutingKey, Permission) ->
     Resource = Name#resource{kind = topic},
-    Context = #{routing_key => RoutingKey},
+    #user{username = Username} = User,
+    #resource{virtual_host = VHost} = Resource,
+
+    Context = #{routing_key => RoutingKey,
+                expand_map  => #{
+                    <<"username">> => Username,
+                    <<"vhost">>    => VHost
+                }
+    },
     Cache = case get(topic_permission_cache) of
                 undefined -> [];
                 Other     -> Other

--- a/src/rabbit_types.erl
+++ b/src/rabbit_types.erl
@@ -186,4 +186,6 @@
 -type(proc_name() :: term()).
 -type(proc_type_and_name() :: {atom(), proc_name()}).
 
--type(topic_access_context() :: #{routing_key => rabbit_router:routing_key(), _ => _}).
+-type(topic_access_context() :: #{routing_key  => rabbit_router:routing_key(),
+                                  variable_map => map(),
+                                  _ => _}).

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -11,13 +11,14 @@
 %% The Original Code is RabbitMQ.
 %%
 %% The Initial Developer of the Original Code is GoPivotal, Inc.
-%% Copyright (c) 2016 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 %%
 
 -module(unit_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("proper/include/proper.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
 
 -compile(export_all).
 
@@ -35,12 +36,52 @@ groups() ->
         version_minor_equivalence_properties,
         version_comparison,
         pid_decompose_compose,
-        auth_backend_internal_expand_topic_permission
+        auth_backend_internal_expand_topic_permission,
+        rabbit_channel_build_topic_variable_map
       ]}
     ].
 
 init_per_group(_, Config) -> Config.
 end_per_group(_, Config) -> Config.
+
+rabbit_channel_build_topic_variable_map(_Config) ->
+    AmqpParams = #amqp_params_direct{
+        adapter_info = #amqp_adapter_info{
+            additional_info = [
+                {variable_map, #{<<"client_id">> => <<"client99">>}}]}
+    },
+    %% simple case
+    #{<<"client_id">> := <<"client99">>,
+      <<"username">>  := <<"guest">>,
+      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+        [{amqp_params, AmqpParams}], <<"default">>, <<"guest">>
+    ),
+    %% nothing to add
+    AmqpParams1 = #amqp_params_direct{adapter_info = #amqp_adapter_info{}},
+    #{<<"username">>  := <<"guest">>,
+      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+        [{amqp_params, AmqpParams1}], <<"default">>, <<"guest">>
+    ),
+    %% nothing to add with amqp_params_network
+    AmqpParams2 = #amqp_params_network{},
+    #{<<"username">>  := <<"guest">>,
+      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+        [{amqp_params, AmqpParams2}], <<"default">>, <<"guest">>
+    ),
+    %% trying to override channel variables, but those
+    %% take precedence
+    AmqpParams3 = #amqp_params_direct{
+        adapter_info = #amqp_adapter_info{
+            additional_info = [
+                {variable_map, #{<<"client_id">> => <<"client99">>,
+                                 <<"username">>  => <<"admin">>}}]}
+    },
+    #{<<"client_id">> := <<"client99">>,
+      <<"username">>  := <<"guest">>,
+      <<"vhost">>     := <<"default">>} = rabbit_channel:build_topic_variable_map(
+        [{amqp_params, AmqpParams3}], <<"default">>, <<"guest">>
+    ),
+    ok.
 
 auth_backend_internal_expand_topic_permission(_Config) ->
     ExpandMap = #{<<"username">> => <<"guest">>, <<"vhost">> => <<"default">>},

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -34,12 +34,47 @@ groups() ->
         version_equivalence,
         version_minor_equivalence_properties,
         version_comparison,
-        pid_decompose_compose
+        pid_decompose_compose,
+        auth_backend_internal_expand_topic_permission
       ]}
     ].
 
 init_per_group(_, Config) -> Config.
 end_per_group(_, Config) -> Config.
+
+auth_backend_internal_expand_topic_permission(_Config) ->
+    ExpandMap = #{<<"username">> => <<"guest">>, <<"vhost">> => <<"default">>},
+    %% simple case
+    <<"services/default/accounts/guest/notifications">> =
+        rabbit_auth_backend_internal:expand_topic_permission(
+            <<"services/{vhost}/accounts/{username}/notifications">>,
+            ExpandMap
+        ),
+    %% replace variable twice
+    <<"services/default/accounts/default/guest/notifications">> =
+        rabbit_auth_backend_internal:expand_topic_permission(
+            <<"services/{vhost}/accounts/{vhost}/{username}/notifications">>,
+            ExpandMap
+        ),
+    %% nothing to replace
+    <<"services/accounts/notifications">> =
+        rabbit_auth_backend_internal:expand_topic_permission(
+            <<"services/accounts/notifications">>,
+            ExpandMap
+        ),
+    %% the expand map isn't defined
+    <<"services/{vhost}/accounts/{username}/notifications">> =
+        rabbit_auth_backend_internal:expand_topic_permission(
+            <<"services/{vhost}/accounts/{username}/notifications">>,
+            undefined
+        ),
+    %% the expand map is empty
+    <<"services/{vhost}/accounts/{username}/notifications">> =
+        rabbit_auth_backend_internal:expand_topic_permission(
+            <<"services/{vhost}/accounts/{username}/notifications">>,
+            #{}
+        ),
+    ok.
 
 pid_decompose_compose(_Config) ->
     Pid = self(),


### PR DESCRIPTION
The expansion is done inside the internal authz backend
and the variables to expand are provided in a map from
the context parameter. This decoupling allows to provide
different variables to expand based on the caller context
(e.g. add other variables to expand from the MQTT plugin).

References rabbitmq/rabbitmq-server#1229