### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,15 @@
 # vim:sw=2:et:
-
-# Use a real VM so we can install all the packages we want.
-sudo: required
+sudo: false
 
 language: erlang
+
 notifications:
   email:
     - alerts@rabbitmq.com
-addons:
-  apt:
-    sources:
-      - sourceline: deb https://packages.erlang-solutions.com/ubuntu precise contrib
-        key_url: https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc
-    packages:
-      # Use Elixir from Erlang Solutions. The provided Elixir is
-      # installed with kiex but is old. By using an prebuilt Debian
-      # package, we save the compilation time.
-      - elixir
-      - xsltproc
+
 otp_release:
   - "18.3"
-  - "19.0"
-  - "19.2"
+  - "19.3"
 
 before_script:
   # The checkout made by Travis is a "detached HEAD" and branches
@@ -35,11 +23,12 @@ before_script:
     git remote add upstream https://github.com/$TRAVIS_REPO_SLUG.git
     git fetch upstream stable:stable || :
     git fetch upstream master:master || :
-  # Remove all kiex installations. This makes sure that the Erlang
-  # Solutions one is picked: it's after the kiex installations in $PATH.
-  - echo YES | kiex implode
+  - kiex selfupdate
+  - test -x ~/.kiex/elixirs/elixir-1.4.4/bin/elixir || kiex install 1.4.4
+  - kiex default 1.4.4
 
 script: make tests
 
 cache:
-  apt: true
+  directories:
+    - ~/.kiex/elixirs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # RabbitMQ Common
 
-## Continuous Integration
-
-[![Build Status](https://travis-ci.org/rabbitmq/rabbitmq-common.svg?branch=master)](https://travis-ci.org/rabbitmq/rabbitmq-common)
+This library is shared between [RabbitMQ server](https://github.com/rabbitmq/rabbitmq-server), [RabbitMQ Erlang client](https://github.com/rabbitmq/rabbitmq-erlang-client)
+and other RabbitMQ ecosystem projects.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# RabbitMQ Common
+
+## Continuous Integration
+
+[![Build Status](https://travis-ci.org/rabbitmq/rabbitmq-common.svg?branch=master)](https://travis-ci.org/rabbitmq/rabbitmq-common)


### PR DESCRIPTION
* No need to use `sudo` which will cause builds to start quite a bit faster.
* Use Travis CI's cache feature to keep from having to build elixir 1.4.4 every time.