### PR TITLE
Use sysctl to get the total memory on Darwin (OS X)

### DIFF
--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -411,14 +411,7 @@ cmd(Command) ->
 %% Original code was part of OTP and released under "Erlang Public License".
 
 get_total_memory({unix,darwin}) ->
-    File = cmd("/usr/bin/vm_stat"),
-    Lines = string:tokens(File, "\n"),
-    Dict = dict:from_list(lists:map(fun parse_line_mach/1, Lines)),
-    [PageSize, Inactive, Active, Free, Wired] =
-        [dict:fetch(Key, Dict) ||
-            Key <- [page_size, 'Pages inactive', 'Pages active', 'Pages free',
-                    'Pages wired down']],
-    PageSize * (Inactive + Active + Free + Wired);
+    sysctl("hw.memsize");
 
 get_total_memory({unix,freebsd}) ->
     PageSize  = sysctl("vm.stats.vm.v_page_size"),
@@ -520,7 +513,7 @@ parse_line_aix(Line) ->
      end}.
 
 sysctl(Def) ->
-    list_to_integer(cmd("/sbin/sysctl -n " ++ Def) -- "\n").
+    list_to_integer(cmd("/usr/bin/env sysctl -n " ++ Def) -- "\n").
 
 %% file:read_file does not work on files in /proc as it seems to get
 %% the size of the file first and then read that many bytes. But files

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -449,19 +449,6 @@ get_total_memory({unix, aix}) ->
 get_total_memory(_OsType) ->
     unknown.
 
-%% A line looks like "Foo bar: 123456."
-parse_line_mach(Line) ->
-    [Name, RHS | _Rest] = string:tokens(Line, ":"),
-    case Name of
-        "Mach Virtual Memory Statistics" ->
-            ["(page", "size", "of", PageSize, "bytes)"] =
-                string:tokens(RHS, " "),
-            {page_size, list_to_integer(PageSize)};
-        _ ->
-            [Value | _Rest1] = string:tokens(RHS, " ."),
-            {list_to_atom(Name), list_to_integer(Value)}
-    end.
-
 %% A line looks like "MemTotal:         502968 kB"
 %% or (with broken OS/modules) "Readahead      123456 kB"
 parse_line_linux(Line) ->


### PR DESCRIPTION
Prior to this change, on a host with 16GB of RAM, RabbitMQ was reporting
total memory as `13719 MiB (14385987584 bytes)`. This was obviously
incorrect, the host has 16384MiB of RAM.

Other notable utilities that use sysctl to report total memory on OS X:

  * Ohai (Chef): https://github.com/chef/ohai/blob/v13.2.0/lib/ohai/plugins/darwin/memory.rb#L25
  * Facter (Puppet): https://github.com/puppetlabs/facter/blob/3.7.0/lib/src/facts/osx/memory_resolver.cc#L17

Using `/usr/bin/env sysctl` since:

  * OS X: `/usr/bin/sysctl`
  * FreeBSD & OpenBSD: `/sbin/sysctl`