### PR TITLE
Stop gen_server2 stats emissions when preparing to hibernate

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -678,9 +678,8 @@ process_next_msg(GS2State0 = #gs2_state { time          = Time,
             after Time1 ->
                     case HibOnTimeout of
                         true ->
-                            GS2State1 = call_emit_stats(GS2State, ignore_timer),
                             pre_hibernate(
-                              GS2State1 #gs2_state { queue = Queue1 });
+                              GS2State #gs2_state { queue = Queue1 });
                         false ->
                             process_msg(timeout,
                                         GS2State #gs2_state { queue = Queue1 })
@@ -711,7 +710,7 @@ hibernate(GS2State = #gs2_state { timeout_state = TimeoutState }) ->
 
 pre_hibernate(GS2State0 = #gs2_state { state   = State,
                                        mod     = Mod }) ->
-    GS2State = maybe_stop_stats_timer(GS2State0),
+    GS2State = call_emit_stats(maybe_stop_stats_timer(GS2State0), ignore_timer),
     case erlang:function_exported(Mod, handle_pre_hibernate, 1) of
         true ->
             case catch Mod:handle_pre_hibernate(State) of

--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -793,9 +793,18 @@ in(Input, Priority, GS2State = #gs2_state { queue = Queue }) ->
 
 process_msg({system, From, Req},
             GS2State = #gs2_state { parent = Parent, debug  = Debug }) ->
-    %% gen_server puts Hib on the end as the 7th arg, but that version
-    %% of the fun seems not to be documented so leaving out for now.
-    sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug, GS2State);
+    case Req of
+        %% This clause will match only in R16B03.
+        %% Since 17.0 replace_state is not a system message.
+        {replace_state, StateFun} ->
+            GS2State1 = StateFun(GS2State),
+            gen:reply(From, GS2State1),
+            system_continue(Parent, Debug, GS2State1);
+        _ ->
+            %% gen_server puts Hib on the end as the 7th arg, but that version
+            %% of the fun seems not to be documented so leaving out for now.
+            sys:handle_system_msg(Req, From, Parent, ?MODULE, Debug, GS2State)
+    end;
 process_msg({'$with_state', From, Fun},
            GS2State = #gs2_state{state = State}) ->
     reply(From, catch Fun(State)),

--- a/src/rabbit_core_metrics.erl
+++ b/src/rabbit_core_metrics.erl
@@ -19,6 +19,7 @@
 -include("rabbit_core_metrics.hrl").
 
 -export([init/0]).
+-export([terminate/0]).
 
 -export([connection_created/2,
          connection_closed/1,
@@ -101,6 +102,11 @@
 init() ->
     [ets:new(Table, [Type, public, named_table, {write_concurrency, true}])
      || {Table, Type} <- ?CORE_TABLES ++ ?CORE_EXTRA_TABLES],
+    ok.
+
+terminate() ->
+    [ets:delete(Table)
+     || {Table, _Type} <- ?CORE_TABLES ++ ?CORE_EXTRA_TABLES],
     ok.
 
 connection_created(Pid, Infos) ->

--- a/src/rabbit_event.erl
+++ b/src/rabbit_event.erl
@@ -90,8 +90,9 @@ start_link() ->
 %%   notify(stats)
 
 init_stats_timer(C, P) ->
-    {ok, StatsLevel} = application:get_env(rabbit, collect_statistics),
-    {ok, Interval}   = application:get_env(rabbit, collect_statistics_interval),
+    %% If the rabbit app is not loaded - use default none:5000
+    StatsLevel = application:get_env(rabbit, collect_statistics, none),
+    Interval   = application:get_env(rabbit, collect_statistics_interval, 5000),
     setelement(P, C, #state{level = StatsLevel, interval = Interval,
                             timer = undefined}).
 

--- a/test/gen_server2_test_server.erl
+++ b/test/gen_server2_test_server.erl
@@ -18,7 +18,7 @@
 -behaviour(gen_server2).
 -record(gs2_state, {parent, name, state, mod, time,
                     timeout_state, queue, debug, prioritisers,
-                    timer, init_stats_fun, emit_stats_fun, stop_stats_fun}).
+                    timer, emit_stats_fun, stop_stats_fun}).
 
 -export([start_link/0, start_link/1, start_link/2, stats_count/1]).
 

--- a/test/gen_server2_test_server.erl
+++ b/test/gen_server2_test_server.erl
@@ -52,7 +52,12 @@ init([]) ->
 init([Time]) ->
     Counter = ets:new(stats_count, [public]),
     ets:insert(Counter, {count, 0}),
-    {ok, #{counter => Counter}, Time}.
+    case Time of
+        {backoff, _, _, _} ->
+            {ok, #{counter => Counter}, hibernate, Time};
+        _ ->
+            {ok, #{counter => Counter}, Time}
+    end.
 
 count_stats(Counter) ->
     ets:update_counter(Counter, count, 1).

--- a/test/gen_server2_test_server.erl
+++ b/test/gen_server2_test_server.erl
@@ -54,17 +54,20 @@ init([Time]) ->
     ets:insert(Counter, {count, 0}),
     case Time of
         {backoff, _, _, _} ->
-            {ok, #{counter => Counter}, hibernate, Time};
+            {ok, {counter, Counter}, hibernate, Time};
         _ ->
-            {ok, #{counter => Counter}, Time}
+            {ok, {counter, Counter}, Time}
     end.
 
 count_stats(Counter) ->
-    ets:update_counter(Counter, count, 1).
+    ets:update_counter(Counter, count, {2, 1}).
 
-handle_call(get_counter,_,State) -> {reply, maps:get(counter, State), State};
-handle_call(hibernate, _, State) -> {reply, ok, State, hibernate};
-handle_call(_,_,State) -> {reply, ok, State}.
+handle_call(get_counter,_, {counter, Counter} = State) ->
+    {reply, Counter, State};
+handle_call(hibernate, _, State) ->
+    {reply, ok, State, hibernate};
+handle_call(_,_,State) ->
+    {reply, ok, State}.
 
 handle_cast({sleep, Time}, State) -> timer:sleep(Time), {noreply, State};
 handle_cast(_,State) -> {noreply, State}.

--- a/test/gen_server2_test_server.erl
+++ b/test/gen_server2_test_server.erl
@@ -1,0 +1,73 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(gen_server2_test_server).
+-behaviour(gen_server2).
+-record(gs2_state, {parent, name, state, mod, time,
+                    timeout_state, queue, debug, prioritisers,
+                    timer, init_stats_fun, emit_stats_fun, stop_stats_fun}).
+
+-export([start_link/0, start_link/1, start_link/2, stats_count/1]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3, handle_post_hibernate/1]).
+
+start_link(count_stats) ->
+    start_link(count_stats, infinity).
+
+start_link(count_stats, Time) ->
+    {ok, Server} = gen_server2:start_link(gen_server2_test_server, [Time], []),
+    Counter = gen_server2:call(Server, get_counter),
+    sys:replace_state(Server,
+        fun(GSState) ->
+            GSState#gs2_state{
+                emit_stats_fun = fun(State) -> count_stats(Counter), State end
+            }
+        end),
+    {ok, Server}.
+
+start_link() ->
+    gen_server2:start_link(gen_server2_test_server, [], []).
+
+stats_count(Server) ->
+    Counter = gen_server2:call(Server, get_counter),
+    [{count, Count}] = ets:lookup(Counter, count),
+    Count.
+
+init([]) ->
+    init([infinity]);
+init([Time]) ->
+    Counter = ets:new(stats_count, [public]),
+    ets:insert(Counter, {count, 0}),
+    {ok, #{counter => Counter}, Time}.
+
+count_stats(Counter) ->
+    ets:update_counter(Counter, count, 1).
+
+handle_call(get_counter,_,State) -> {reply, maps:get(counter, State), State};
+handle_call(hibernate, _, State) -> {reply, ok, State, hibernate};
+handle_call(_,_,State) -> {reply, ok, State}.
+
+handle_cast({sleep, Time}, State) -> timer:sleep(Time), {noreply, State};
+handle_cast(_,State) -> {noreply, State}.
+
+handle_post_hibernate(State) -> {noreply, State}.
+
+handle_info(_,State) -> {noreply, State}.
+
+terminate(_,_State) -> ok.
+
+code_change(_,State,_) -> {ok, State}.

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -47,7 +47,7 @@ groups() ->
             parse_mem_relative_integer,
             parse_mem_relative_invalid
         ]},
-        {gen_server2, [], [
+        {gen_server2, [parallel], [
             stats_timer_is_working,
             stats_timer_writes_gen_server2_metrics_if_core_metrics_ets_exists,
             stop_stats_timer_on_hibernation,


### PR DESCRIPTION
Fixes #196, follow up to #197 

Stop the stats emission timer before waiting for the backoff timeout.

Includes some changes to the `gen_server2` stats emission callback logic. Callbacks now only emit stats, while timer and `gs2_state` is managed by `gen_server2` itself. It makes it easier to control the timer and test.