### PR TITLE
Optimise memory reporting to call less system memory reports.

### DIFF
--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -380,9 +380,9 @@ parse_mem_limit(MemLimit) ->
     ),
     ?DEFAULT_VM_MEMORY_HIGH_WATERMARK.
 
-internal_update(State = #state { memory_limit   = MemLimit,
-                                 alarmed        = Alarmed,
-                                 alarm_funs     = {AlarmSet, AlarmClear} }) ->
+internal_update(State = #state { memory_limit = MemLimit,
+                                 alarmed      = Alarmed,
+                                 alarm_funs   = {AlarmSet, AlarmClear} }) ->
     ProcMem = get_process_memory(),
     NewAlarmed = ProcMem > MemLimit,
     case {Alarmed, NewAlarmed} of

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -54,7 +54,7 @@
 
 -include("rabbit_memory.hrl").
 
--define(MEM_CACHE_EXP, 500).
+-define(MEM_CACHE_EXP, 1000).
 
 %%----------------------------------------------------------------------------
 
@@ -389,7 +389,7 @@ parse_mem_limit(MemLimit) ->
 internal_update(State = #state { memory_limit = MemLimit,
                                  alarmed      = Alarmed,
                                  alarm_funs   = {AlarmSet, AlarmClear} }) ->
-    MemUsed = get_process_memory(),
+    MemUsed = get_process_memory_cached(),
     NewAlarmed = MemUsed > MemLimit,
     case {Alarmed, NewAlarmed} of
         {false, true} -> emit_update_info(set, MemUsed, MemLimit),

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -55,8 +55,6 @@
 
 -include("rabbit_memory.hrl").
 
--define(MEM_CACHE_EXP, 1000).
-
 %%----------------------------------------------------------------------------
 
 -type vm_memory_high_watermark() :: (float() | {'absolute', integer() | string()}).


### PR DESCRIPTION
System RSS reporting functions can take some time to execute, especially when called concurrently. To optimise that on hot code paths we cache the last value for 500 ms.
It won't affect regular memory collection functions for memory alarms and management stats (which happens every 1 sec), only calls from `file_handle_cache`, which can be called concurrently.

Addresses rabbitmq/rabbitmq-server#1343