### PR TITLE
Use Recon allocator information to compute the amount of RAM used by the node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ define PROJECT_APP_EXTRA_KEYS
 	  ]}
 endef
 
-DEPS = recon
+BUILD_DEPS = recon
 LOCAL_DEPS = compiler syntax_tools xmerl
 
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -166,7 +166,7 @@ get_memory_calculation_strategy() ->
               "Defaulting to 'rss'",
               [UnsupportedValue]
             ),
-            rss
+            allocated
     end.
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
This is another take on #224. #225 was reverted because it had side-effects on the Erlang client and test suites.