### PR TITLE
Use recon_alloc to get memory info on Win32, /proc on Linux, ps for other OS types

### DIFF
--- a/LICENSE-BSD-recon
+++ b/LICENSE-BSD-recon
@@ -1,0 +1,27 @@
+Copyright (c) 2012-2017, Frédéric Trottier-Hébert
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+  The names of its contributors may not be used to endorse or promote
+  products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ define PROJECT_APP_EXTRA_KEYS
 	  ]}
 endef
 
+DEPS = recon
 LOCAL_DEPS = compiler syntax_tools xmerl
 
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -152,7 +152,7 @@ get_process_memory() ->
 
 -spec get_memory_calculation_strategy() -> rss | erlang.
 get_memory_calculation_strategy() ->
-    case rabbit_misc:get_env(rabbit, vm_memory_calculation_strategy, rss) of
+    case rabbit_misc:get_env(rabbit, vm_memory_calculation_strategy, allocated) of
         allocated -> allocated;
         erlang -> erlang;
         legacy -> erlang; %% backwards compatibility
@@ -161,10 +161,10 @@ get_memory_calculation_strategy() ->
             rabbit_log:warning(
               "Unsupported value '~p' for vm_memory_calculation_strategy. "
               "Supported values: (allocated|erlang|legacy|rss). "
-              "Defaulting to 'rss'",
+              "Defaulting to 'allocated'",
               [UnsupportedValue]
             ),
-            rss
+            allocated
     end.
 
 %%----------------------------------------------------------------------------

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -130,30 +130,35 @@ get_memory_use(ratio) ->
 %% be equal to the total size of all pages mapped to the emulator,
 %% according to http://erlang.org/doc/man/erlang.html#memory-0
 %% erlang:memory(total) under-reports memory usage by around 20%
+%%
+%% Win32 Note: 3.6.12 shipped with code that used wmic.exe to get the
+%% WorkingSetSize value for the running erl.exe process. Unfortunately
+%% even with a moderate invocation rate of 1 ops/second that uses more
+%% CPU resources than some Windows users are willing to tolerate.
+%% See rabbitmq/rabbitmq-server#1343 and rabbitmq/rabbitmq-common#224
+%% for details.
 -spec get_process_memory() -> Bytes :: integer().
 get_process_memory() ->
-    case get_memory_calculation_strategy() of
-        rss ->
-            case get_system_process_resident_memory() of
-                {ok, MemInBytes} ->
-                    MemInBytes;
-                {error, Reason}  ->
-                    rabbit_log:debug("Unable to get system memory used. Reason: ~p."
-                                     " Falling back to erlang memory reporting",
-                                     [Reason]),
-                    erlang:memory(total)
-            end;
-        erlang ->
-            erlang:memory(total)
-    end.
+    get_process_memory_using_strategy(get_memory_calculation_strategy()).
+
+get_process_memory_using_strategy(allocated) ->
+    recon_alloc:memory(allocated);
+%% backwards compatibility
+get_process_memory_using_strategy(erlang) ->
+    erlang:memory(total);
+get_process_memory_using_strategy(legacy) ->
+    erlang:memory(total);
+%% backwards compatibility
+get_process_memory_using_strategy(rss) ->
+    recon_alloc:memory(allocated).
 
 -spec get_memory_calculation_strategy() -> rss | erlang.
 get_memory_calculation_strategy() ->
     case rabbit_misc:get_env(rabbit, vm_memory_calculation_strategy, rss) of
-        erlang ->
-            erlang;
-        rss ->
-            rss;
+        allocated -> allocated;
+        erlang -> erlang;
+        legacy -> legacy;
+        rss -> rss;
         UnsupportedValue ->
             rabbit_log:warning(
               "Unsupported value '~p' for vm_memory_calculation_strategy. "
@@ -162,54 +167,6 @@ get_memory_calculation_strategy() ->
               [UnsupportedValue]
             ),
             rss
-    end.
-
--spec get_system_process_resident_memory() -> {ok, Bytes :: integer()} | {error, term()}.
-get_system_process_resident_memory() ->
-    try
-        get_system_process_resident_memory(os:type())
-    catch _:Error ->
-            {error, {"Failed to get process resident memory", Error}}
-    end.
-
-get_system_process_resident_memory({unix,darwin}) ->
-    get_ps_memory();
-
-get_system_process_resident_memory({unix, linux}) ->
-    get_ps_memory();
-
-get_system_process_resident_memory({unix,freebsd}) ->
-    get_ps_memory();
-
-get_system_process_resident_memory({unix,openbsd}) ->
-    get_ps_memory();
-
-get_system_process_resident_memory({win32,_OSname}) ->
-    %% Note: 3.6.12 shipped with code that used wmic.exe to get the
-    %% WorkingSetSize value for the running erl.exe process. Unfortunately
-    %% even with a moderate invocation rate of 1 ops/second that uses more
-    %% CPU resources than some Windows users are willing to tolerate.
-    %% See rabbitmq/rabbitmq-server#1343 for details.
-    {ok, erlang:memory(total)};
-
-get_system_process_resident_memory({unix, sunos}) ->
-    get_ps_memory();
-
-get_system_process_resident_memory({unix, aix}) ->
-    get_ps_memory();
-
-get_system_process_resident_memory(_OsType) ->
-    {error, not_implemented_for_os}.
-
-get_ps_memory() ->
-    OsPid = os:getpid(),
-    Cmd = "ps -p " ++ OsPid ++ " -o rss=",
-    CmdOutput = os:cmd(Cmd),
-    case re:run(CmdOutput, "[0-9]+", [{capture, first, list}]) of
-        {match, [Match]} ->
-            {ok, list_to_integer(Match) * 1024};
-        _ ->
-            {error, {unexpected_output_from_command, Cmd, CmdOutput}}
     end.
 
 %%----------------------------------------------------------------------------
@@ -424,18 +381,18 @@ cmd(Command) ->
 %% Windows and Freebsd code based on: memsup:get_memory_usage/1
 %% Original code was part of OTP and released under "Erlang Public License".
 
-get_total_memory({unix,darwin}) ->
+get_total_memory({unix, darwin}) ->
     sysctl("hw.memsize");
 
-get_total_memory({unix,freebsd}) ->
+get_total_memory({unix, freebsd}) ->
     PageSize  = sysctl("vm.stats.vm.v_page_size"),
     PageCount = sysctl("vm.stats.vm.v_page_count"),
     PageCount * PageSize;
 
-get_total_memory({unix,openbsd}) ->
+get_total_memory({unix, openbsd}) ->
     sysctl("hw.usermem");
 
-get_total_memory({win32,_OSname}) ->
+get_total_memory({win32, _OSname}) ->
     [Result|_] = os_mon_sysinfo:get_mem_info(),
     {ok, [_MemLoad, TotPhys, _AvailPhys, _TotPage, _AvailPage, _TotV, _AvailV],
      _RestStr} =

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -143,30 +143,24 @@ get_process_memory() ->
 
 get_process_memory_using_strategy(allocated) ->
     recon_alloc:memory(allocated);
-%% backwards compatibility
 get_process_memory_using_strategy(erlang) ->
-    erlang:memory(total);
-get_process_memory_using_strategy(legacy) ->
-    erlang:memory(total);
-%% backwards compatibility
-get_process_memory_using_strategy(rss) ->
-    recon_alloc:memory(allocated).
+    erlang:memory(total).
 
 -spec get_memory_calculation_strategy() -> rss | erlang.
 get_memory_calculation_strategy() ->
     case rabbit_misc:get_env(rabbit, vm_memory_calculation_strategy, rss) of
         allocated -> allocated;
         erlang -> erlang;
-        legacy -> legacy;
-        rss -> rss;
+        legacy -> erlang; %% backwards compatibility
+        rss -> allocated; %% backwards compatibility
         UnsupportedValue ->
             rabbit_log:warning(
               "Unsupported value '~p' for vm_memory_calculation_strategy. "
-              "Supported values: (rss|erlang). "
-              "Defaulting to 'rss'",
+              "Supported values: (allocated|erlang|legacy|rss). "
+              "Defaulting to 'allocated'",
               [UnsupportedValue]
             ),
-            rss
+            allocated
     end.
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #224.

Also see rabbitmq/rabbitmq-erlang-client#92 and https://github.com/rabbitmq/rabbitmq-server/pull/1389.