### PR TITLE
fix supervisor2's state for get {badrecord,state} error when release upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,12 @@ ifeq ($(call compare_version,$(ERTS_VER),$(tls_atom_version_MAX_ERTS_VER),<),tru
 RMQ_ERLC_OPTS += -Ddefine_tls_atom_version
 endif
 
+# supervisor's state change from erts-7.0(18)
+new_sup2_state_MAX_ERTS_VER = 7.0
+ifeq ($(call compare_version,$(ERTS_VER),$(new_sup2_state_MAX_ERTS_VER),>),true)
+RMQ_ERLC_OPTS += -Ddefine_new_sup2_state
+endif
+
 # For src/*_compat.erl modules, we don't want to set -Werror because for
 # instance, warnings about removed functions (e.g. ssl:connection_info/1
 # in Erlang 20) can't be turned off.

--- a/src/supervisor2.erl
+++ b/src/supervisor2.erl
@@ -118,6 +118,7 @@
 
 -include("include/old_builtin_types.hrl").
 
+-ifndef(define_new_sup2_state).
 -record(state, {name,
 		strategy               :: strategy(),
 		children = []          :: [child_rec()],
@@ -127,6 +128,18 @@
 		restarts = [],
 	        module,
 	        args}).
+-else.
+-record(state, {name,
+		strategy               :: strategy(),
+		children = []          :: [child_rec()],
+		dynamics               :: ?DICT_TYPE() | ?SET_TYPE(),
+		intensity              :: non_neg_integer(),
+		period                 :: pos_integer(),
+		restarts = [],
+		dynamic_restarts = 0   :: non_neg_integer(),
+	        module,
+	        args}).
+-endif.
 -type state() :: #state{}.
 
 -define(is_simple(State), State#state.strategy =:= simple_one_for_one).


### PR DESCRIPTION
`supervisor`'s state change from `otp-18` and add a field, but `supervisor2` didn't.
So, when i do release upgrade it will print a error msg:
```
<0.1153.0> reason: {'EXIT',
                       {{badrecord,state},
                        [{supervisor,get_callback_module,1,
                             [{file,'supervisor.erl'},{line,266}]},
                         {release_handler_1,get_supervisor_module,1,
                             [{file,'release_handler_1.erl'},{line,684}]},
                         {release_handler_1,get_master_procs,3,
                             [{file,'release_handler_1.erl'},{line,605}]},
                         {lists,foldl,3,[{file,'lists.erl'},{line,1262}]},
                         {release_handler_1,eval,2,
                             [{file,'release_handler_1.erl'},{line,375}]},
                         {lists,foldl,3,[{file,'lists.erl'},{line,1262}]},
                         {release_handler_1,eval_script,5,
                             [{file,'release_handler_1.erl'},{line,102}]},
                         {release_handler,eval_script,5,
                             [{file,'release_handler.erl'},{line,368}]}]}}
release_handler: cannot find top supervisor for application amqp_client
```
For fix this, i just add a field in new otp version.