### PR TITLE
Default mem calc strategy should be "rss"

### DIFF
--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -144,7 +144,7 @@ get_process_memory() ->
 
 -spec get_memory_calculation_strategy() -> rss | erlang.
 get_memory_calculation_strategy() ->
-    case rabbit_misc:get_env(rabbit, vm_memory_calculation_strategy, allocated) of
+    case rabbit_misc:get_env(rabbit, vm_memory_calculation_strategy, rss) of
         allocated -> allocated;
         erlang -> erlang;
         legacy -> erlang; %% backwards compatibility
@@ -153,10 +153,10 @@ get_memory_calculation_strategy() ->
             rabbit_log:warning(
               "Unsupported value '~p' for vm_memory_calculation_strategy. "
               "Supported values: (allocated|erlang|legacy|rss). "
-              "Defaulting to 'allocated'",
+              "Defaulting to 'rss'",
               [UnsupportedValue]
             ),
-            allocated
+            rss
     end.
 
 %%----------------------------------------------------------------------------


### PR DESCRIPTION
This is due to a scenario in which the Erlang VM allocator stats report a huge increase in memory consumption which is only reflected in VSS increase, not RSS

PT #152081051