### PR TITLE
Introduce handle_info callback

### DIFF
--- a/src/rabbit_backing_queue.erl
+++ b/src/rabbit_backing_queue.erl
@@ -265,4 +265,9 @@
                             [ack()], Acc, state())
                            -> Acc.
 
+%% Called when rabbit_amqqueue_process receives a message via
+%% handle_info and it should be processed by the backing
+%% queue
+-callback handle_info(term(), state()) -> state().
+
 info_keys() -> ?INFO_KEYS.


### PR DESCRIPTION
This can be used to handle generic messages that the parent `gen_server2` wishes to pass to backing queues. Initially used for the bump_reduce_memory_use message.

Part of rabbitmq/rabbitmq-server#1393