### PR TITLE
Peer discovery backend: add an optional init callback

### DIFF
--- a/src/rabbit_peer_discovery_backend.erl
+++ b/src/rabbit_peer_discovery_backend.erl
@@ -38,6 +38,8 @@
 
 -include("rabbit.hrl").
 
+-callback init() -> ok | {error, Reason :: string()}.
+
 -callback list_nodes() -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} |
                           {error, Reason :: string()}.
 
@@ -52,3 +54,5 @@
 -callback lock(Node :: atom())   -> {ok, Data :: term()} | not_supported | {error, Reason :: string()}.
 
 -callback unlock(Data :: term()) -> ok | {error, Reason :: string()}.
+
+-optional_callbacks([init/0]).


### PR DESCRIPTION
Note that this should not be a breaking change: all known implementations of this (barely shipped) interface currently ship with RabbitMQ and the callback is optional.

Part of rabbitmq/rabbitmq-peer-discovery-common#5.

[#153615554]