### PR TITLE
Extend amqqueue record to include queue type

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -143,7 +143,8 @@
           policy_version,
           slave_pids_pending_shutdown,
           vhost,                       %% secondary index
-          options = #{}}).
+          options = #{},
+          type = classic }).           %% immutable
 
 -record(exchange_serial, {name, next}).
 


### PR DESCRIPTION
Part of the new high availability implementation using raft as a consensus algorithm

Type defaults to 'classic'

[#154472130]