### PR TITLE
Revert "ssl_compat: Silence Dialyzer warning about ssl:connection_inf…

### DIFF
--- a/src/ssl_compat.erl
+++ b/src/ssl_compat.erl
@@ -19,9 +19,6 @@
 %% We don't want warnings about the use of ssl:connection_info/1 in this
 %% module.
 -compile(nowarn_deprecated_function).
--dialyzer({nowarn_function,
-           [connection_information_pre_18/1,
-            connection_information_pre_18/2]}).
 
 %% Declare versioned functions to allow dynamic code loading,
 %% depending on the Erlang version running. See 'code_version.erl' for details


### PR DESCRIPTION
…o/1"

This reverts commit c9f924c136facb755f0605cfdbb2f67407cf4933.

At first I thought about fixing `code_version` to recognize the `-dialyzer` attribute and update it accordingly, but as the `ssl_compat` module does not exist in `v3.7.x` and later branches it didn't seem worth the effort at this point.