### PR TITLE
Hide common_test node (3.6.x)

### DIFF
--- a/mk/rabbitmq-early-test.mk
+++ b/mk/rabbitmq-early-test.mk
@@ -23,6 +23,15 @@ endif
 # Common Test flags.
 # --------------------------------------------------------------------
 
+# We start the common_test node as a hidden Erlang node. The benefit
+# is that other Erlang nodes won't try to connect to each other after
+# discovering the common_test node if they are not meant to.
+#
+# This helps when several unrelated RabbitMQ clusters are started in
+# parallel.
+
+CT_OPTS += -hidden
+
 # Enable the following common_test hooks on Travis and Concourse:
 #
 # cth_fail_fast

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -875,7 +875,7 @@ is_process_alive(Pid) when node(Pid) =:= node() ->
     erlang:is_process_alive(Pid);
 is_process_alive(Pid) ->
     Node = node(Pid),
-    lists:member(Node, [node() | nodes()]) andalso
+    lists:member(Node, [node() | nodes(connected)]) andalso
         rpc:call(Node, erlang, is_process_alive, [Pid]) =:= true.
 
 pget(K, P) ->


### PR DESCRIPTION
As commented in `rabbitmq-early-test.mk`:

> We start the common_test node as a hidden Erlang node. The benefit is that other Erlang nodes won't try to connect to each other after discovering the common_test node if they are not meant to.
>
> This helps when several unrelated RabbitMQ clusters are started in parallel.
