### PR TITLE
Delete metrics for all deleted queues in 4 ETS operations (v3.7.x)

### DIFF
--- a/src/rabbit_core_metrics.erl
+++ b/src/rabbit_core_metrics.erl
@@ -265,28 +265,34 @@ delete_queue_metrics(Queue) ->
     ok.
 
 delete_channel_queue_exchange_metrics(MatchSpecCondition) ->
-    ets:select_replace(
+    ChannelQueueExchangeMetricsToUpdate = ets:select(
         channel_queue_exchange_metrics,
         [
             {
-                {{'$2', {'$1', '$3'}}, '$4', '_'},
+                {{'$2', {'$1', '$3'}}, '_', '_'},
                 [MatchSpecCondition],
-                [{{{{'$2', {{'$1', '$3'}}}}, '$4', 1}}]
+                [{{'$2', {{'$1', '$3'}}}}]
             }
         ]
-    ).
+    ),
+    lists:foreach(fun(Key) ->
+        ets:update_element(channel_queue_exchange_metrics, Key, {3, 1})
+    end, ChannelQueueExchangeMetricsToUpdate).
 
 delete_channel_queue_metrics(MatchSpecCondition) ->
-    ets:select_replace(
+    ChannelQueueMetricsToUpdate = ets:select(
         channel_queue_metrics,
         [
             {
-                {{'$2', '$1'}, '$3', '$4', '$5', '$6', '$7', '$8', '_'},
+                {{'$2', '$1'}, '_', '_', '_', '_', '_', '_', '_'},
                 [MatchSpecCondition],
-                [{{{{'$2', '$1'}}, '$3', '$4', '$5', '$6', '$7', '$8', 1}}]
+                [{{'$2', '$1'}}]
             }
         ]
-    ).
+    ),
+    lists:foreach(fun(Key) ->
+        ets:update_element(channel_queue_metrics, Key, {8, 1})
+    end, ChannelQueueMetricsToUpdate).
 
 % [{'orelse',
 %    {'==', {Queue}, '$1'},

--- a/src/rabbit_core_metrics.erl
+++ b/src/rabbit_core_metrics.erl
@@ -40,7 +40,8 @@
 
 -export([queue_stats/2,
          queue_stats/5,
-         queue_deleted/1]).
+         queue_deleted/1,
+         queues_deleted/1]).
 
 -export([node_stats/2]).
 
@@ -240,6 +241,61 @@ queue_deleted(Name) ->
     lists:foreach(fun(Key) ->
                           ets:update_element(channel_queue_metrics, Key, {8, 1})
                   end, CQ).
+
+queues_deleted(Queues) ->
+    [ delete_queue_metrics(Queue) || Queue <- Queues ],
+    MatchSpecCondition = build_match_spec_conditions_to_delete_all_queues(Queues),
+    delete_channel_queue_exchange_metrics(MatchSpecCondition),
+    delete_channel_queue_metrics(MatchSpecCondition),
+    ok.
+
+delete_queue_metrics(Queue) ->
+    ets:delete(queue_coarse_metrics, Queue),
+    ets:update_element(queue_metrics, Queue, {3, 1}),
+    ok.
+
+delete_channel_queue_exchange_metrics(MatchSpecCondition) ->
+    ets:select_replace(
+        channel_queue_exchange_metrics,
+        [
+            {
+                {{'$2', {'$1', '$3'}}, '$4', '_'},
+                [MatchSpecCondition],
+                [{{{{'$2', {{'$1', '$3'}}}}, '$4', 1}}]
+            }
+        ]
+    ).
+
+delete_channel_queue_metrics(MatchSpecCondition) ->
+    ets:select_replace(
+        channel_queue_metrics,
+        [
+            {
+                {{'$2', '$1'}, '$3', '$4', '$5', '$6', '$7', '$8', '_'},
+                [MatchSpecCondition],
+                [{{{{'$2', '$1'}}, '$3', '$4', '$5', '$6', '$7', '$8', 1}}]
+            }
+        ]
+    ).
+
+% [{'orelse',
+%    {'==', {Queue}, '$1'},
+%    {'orelse',
+%        {'==', {Queue}, '$1'},
+%        % ...
+%            {'orelse',
+%                {'==', {Queue}, '$1'},
+%                {'==', true, true}
+%            }
+%    }
+%  }],
+build_match_spec_conditions_to_delete_all_queues([Queue|Queues]) ->
+     {'orelse',
+         {'==', {Queue}, '$1'},
+         build_match_spec_conditions_to_delete_all_queues(Queues)
+     };
+build_match_spec_conditions_to_delete_all_queues([]) ->
+    true.
 
 node_stats(persister_metrics, Infos) ->
     ets:insert(node_persister_metrics, {node(), Infos}),

--- a/src/rabbit_event.erl
+++ b/src/rabbit_event.erl
@@ -65,7 +65,17 @@
 %%----------------------------------------------------------------------------
 
 start_link() ->
-    gen_event:start_link({local, ?MODULE}, [{spawn_opt, [{fullsweep_after, 0}]}]).
+    %% gen_event:start_link/2 is not available before OTP 20
+    %% RabbitMQ 3.7 supports OTP >= 19.3
+    case erlang:function_exported(gen_event, start_link, 2) of
+        true ->
+            gen_event:start_link(
+              {local, ?MODULE},
+              [{spawn_opt, [{fullsweep_after, 0}]}]
+            );
+        false ->
+            gen_event:start_link({local, ?MODULE})
+    end.
 
 %% The idea is, for each stat-emitting object:
 %%

--- a/src/rabbit_event.erl
+++ b/src/rabbit_event.erl
@@ -65,7 +65,7 @@
 %%----------------------------------------------------------------------------
 
 start_link() ->
-    gen_event:start_link({local, ?MODULE}).
+    gen_event:start_link({local, ?MODULE}, [{spawn_opt, [{fullsweep_after, 0}]}]).
 
 %% The idea is, for each stat-emitting object:
 %%


### PR DESCRIPTION
Rather than using 6 ETS operations per deleted queue, build a match
spec for every 1000 queues that uses `ets:select_replace/2` to delete
metrics in fewer ETS operations.

Great suggestions @michaelklishin & @hairyhum!
https://github.com/rabbitmq/rabbitmq-server/commit/ee0951b1b3c202eb261ad1830f28ab81904a7334#comments

This should be merged together with rabbitmq/rabbitmq-server#1526

For initial context, see rabbitmq/rabbitmq-server#1513.

Partner-in-crime: @essen