### PR TITLE
Revert "Delete metrics for all deleted queues in 4 ETS operations (master)"

### DIFF
--- a/src/rabbit_core_metrics.erl
+++ b/src/rabbit_core_metrics.erl
@@ -40,8 +40,7 @@
 
 -export([queue_stats/2,
          queue_stats/5,
-         queue_deleted/1,
-         queues_deleted/1]).
+         queue_deleted/1]).
 
 -export([node_stats/2]).
 
@@ -241,71 +240,6 @@ queue_deleted(Name) ->
     lists:foreach(fun(Key) ->
                           ets:update_element(channel_queue_metrics, Key, {8, 1})
                   end, CQ).
-
-queues_deleted(Queues) ->
-    [ delete_queue_metrics(Queue) || Queue <- Queues ],
-    [
-        begin
-            MatchSpecCondition = build_match_spec_conditions_to_delete_all_queues(QueuesPartition),
-            delete_channel_queue_exchange_metrics(MatchSpecCondition),
-            delete_channel_queue_metrics(MatchSpecCondition)
-        end || QueuesPartition <- partition_queues(Queues)
-    ],
-    ok.
-
-partition_queues(Queues) when length(Queues) >= 1000 ->
-    {Partition, Rest} = lists:split(1000, Queues),
-    [Partition | partition_queues(Rest)];
-partition_queues(Queues) ->
-    [Queues].
-
-delete_queue_metrics(Queue) ->
-    ets:delete(queue_coarse_metrics, Queue),
-    ets:update_element(queue_metrics, Queue, {3, 1}),
-    ok.
-
-delete_channel_queue_exchange_metrics(MatchSpecCondition) ->
-    ets:select_replace(
-        channel_queue_exchange_metrics,
-        [
-            {
-                {{'$2', {'$1', '$3'}}, '$4', '_'},
-                [MatchSpecCondition],
-                [{{{{'$2', {{'$1', '$3'}}}}, '$4', 1}}]
-            }
-        ]
-    ).
-
-delete_channel_queue_metrics(MatchSpecCondition) ->
-    ets:select_replace(
-        channel_queue_metrics,
-        [
-            {
-                {{'$2', '$1'}, '$3', '$4', '$5', '$6', '$7', '$8', '_'},
-                [MatchSpecCondition],
-                [{{{{'$2', '$1'}}, '$3', '$4', '$5', '$6', '$7', '$8', 1}}]
-            }
-        ]
-    ).
-
-% [{'orelse',
-%    {'==', {Queue}, '$1'},
-%    {'orelse',
-%        {'==', {Queue}, '$1'},
-%        % ...
-%            {'orelse',
-%                {'==', {Queue}, '$1'},
-%                {'==', true, true}
-%            }
-%    }
-%  }],
-build_match_spec_conditions_to_delete_all_queues([Queue|Queues]) ->
-     {'orelse',
-         {'==', {Queue}, '$1'},
-         build_match_spec_conditions_to_delete_all_queues(Queues)
-     };
-build_match_spec_conditions_to_delete_all_queues([]) ->
-    true.
 
 node_stats(persister_metrics, Infos) ->
     ets:insert(node_persister_metrics, {node(), Infos}),

--- a/src/rabbit_event.erl
+++ b/src/rabbit_event.erl
@@ -65,7 +65,7 @@
 %%----------------------------------------------------------------------------
 
 start_link() ->
-    gen_event:start_link({local, ?MODULE}, [{spawn_opt, [{fullsweep_after, 0}]}]).
+    gen_event:start_link({local, ?MODULE}).
 
 %% The idea is, for each stat-emitting object:
 %%


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-common#259.

`ets:select_replace/2` is not available in OTP 19.3 😢.