### PR TITLE
Compile on Erlang/OTP 21

### DIFF
--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -274,12 +274,18 @@ start-background-broker: node-tmpdir $(RABBITMQ_ENABLED_PLUGINS_FILE)
 	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) status >/dev/null
 
 start-rabbit-on-node:
-	$(exec_verbose) echo 'rabbit:start().' | $(ERL_CALL) $(ERL_CALL_OPTS) | sed -E '/^\{ok, ok\}$$/d'
+	$(exec_verbose) ERL_LIBS="$(DIST_ERL_LIBS)" \
+	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) \
+	  eval 'rabbit:start().' | \
+	  sed -E -e '/^ completed with .* plugins\.$$/d' -e '/^ok$$/d'
 	$(verbose) ERL_LIBS="$(DIST_ERL_LIBS)" \
 	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) wait $(RABBITMQ_PID_FILE)
 
 stop-rabbit-on-node:
-	$(exec_verbose) echo 'rabbit:stop().' | $(ERL_CALL) $(ERL_CALL_OPTS) | sed -E '/^\{ok, ok\}$$/d'
+	$(exec_verbose) ERL_LIBS="$(DIST_ERL_LIBS)" \
+	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) \
+	  eval 'rabbit:stop().' | \
+	  sed -E -e '/^ok$$/d'
 
 stop-node:
 	$(exec_verbose) ( \
@@ -330,9 +336,11 @@ stop-brokers stop-cluster:
 # --------------------------------------------------------------------
 
 set-resource-alarm:
-	$(exec_verbose) echo 'rabbit_alarm:set_alarm({{resource_limit, $(SOURCE), node()}, []}).' | \
-	$(ERL_CALL) $(ERL_CALL_OPTS)
+	$(exec_verbose) ERL_LIBS="$(DIST_ERL_LIBS)" \
+	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) \
+	  eval 'rabbit_alarm:set_alarm({{resource_limit, $(SOURCE), node()}, []}).'
 
 clear-resource-alarm:
-	$(exec-verbose) echo 'rabbit_alarm:clear_alarm({resource_limit, $(SOURCE), node()}).' | \
-	$(ERL_CALL) $(ERL_CALL_OPTS)
+	$(exec_verbose) ERL_LIBS="$(DIST_ERL_LIBS)" \
+	  $(RABBITMQCTL) -n $(RABBITMQ_NODENAME) \
+	  eval 'rabbit_alarm:clear_alarm({resource_limit, $(SOURCE), node()}).'

--- a/src/delegate.erl
+++ b/src/delegate.erl
@@ -47,6 +47,10 @@
 
 -behaviour(gen_server2).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -export([start_link/1, start_link/2, invoke_no_result/2,
          invoke/2, invoke/3, monitor/2, monitor/3, demonitor/1]).
 

--- a/src/rabbit_pbe.erl
+++ b/src/rabbit_pbe.erl
@@ -23,7 +23,7 @@
 %% Supported ciphers and hashes
 
 supported_ciphers() ->
-    NotSupportedByUs = [aes_ctr, aes_ecb, des_ecb, blowfish_ecb, rc4, aes_gcm],
+    NotSupportedByUs = [aes_ctr, aes_ecb, des_ecb, blowfish_ecb, rc4, aes_gcm, chacha20_poly1305],
     SupportedByCrypto = proplists:get_value(ciphers, crypto:supports()),
     lists:filter(fun(Cipher) ->
         not lists:member(Cipher, NotSupportedByUs)

--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -27,6 +27,10 @@
 
 -behaviour(gen_server).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 -export([start_link/1, start_link/3]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,


### PR DESCRIPTION
## Proposed Changes

This is one of the PRs that makes RabbitMQ build successfully on Erlang/OTP 21.

OTP 21 deprecated `erlang:get_stacktrace/0` in favor of a new
try/catch syntax. Unfortunately that's not realistic for projects
that support multiple Erlang versions (like us) until OTP 21 can be
the minimum version requirement. In order to compile we have to ignore
the warning. The broad compiler option seems to be the most common
way to support compilation on multiple OTP versions with `warnings_as_errors`: if we use
a function-specific option it will fail on the releases where the function is not deprecated.

## Types of Changes

- [x] Bug fix (non-breaking change related to https://github.com/rabbitmq/rabbitmq-server/issues/1616)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

[#157964874]
