### PR TITLE
Make rabbit_event:notify not fail if rabbit_event is not started yet.

### DIFF
--- a/src/rabbit_event.erl
+++ b/src/rabbit_event.erl
@@ -156,7 +156,8 @@ notify_if(false, _Type, _Props) -> ok.
 notify(Type, Props) -> notify(Type, Props, none).
 
 notify(Type, Props, Ref) ->
-    gen_event:notify(?MODULE, event_cons(Type, Props, Ref)).
+    %% Using {Name, node()} here to not fail if the event handler is not started
+    gen_event:notify({?MODULE, node()}, event_cons(Type, Props, Ref)).
 
 sync_notify(Type, Props) -> sync_notify(Type, Props, none).
 


### PR DESCRIPTION
If resource alarm is triggered during the boot process it will send
an event via rabbit_event:notify. This can crash the node if rabbit_event
is not started yet. rabbit_event starts after rabbit_alarm and any alarms
on boot were crashing the node.

Calling gen_event:notify with {rabbit_event, node()} is the same as with
rabbit_event except it does not fail.

Fixes https://github.com/rabbitmq/rabbitmq-server/issues/1644