### PR TITLE
erlang/otp 21 deprecated erlang:get_stacktrace/0 function, use the fu…

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -298,3 +298,11 @@
 %% Store metadata in the trace files when message tracing is enabled.
 -define(LG_INFO(Info), is_pid(whereis(lg)) andalso (lg ! Info)).
 -define(LG_PROCESS_TYPE(Type), ?LG_INFO(#{process_type => Type})).
+
+-ifdef(OTP_RELEASE). %% this implies 21 or higher
+-define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
+-define(GET_STACK(Stacktrace), Stacktrace).
+-else.
+-define(EXCEPTION(Class, Reason, _), Class:Reason).
+-define(GET_STACK(_), erlang:get_stacktrace()).
+-endif.


### PR DESCRIPTION
…nction as platform version detected