### PR TITLE
Improve error case if erl / erl.exe is not in PATH

### DIFF
--- a/src/rabbit_nodes_common.erl
+++ b/src/rabbit_nodes_common.erl
@@ -71,10 +71,17 @@ epmd_port() ->
     end.
 
 ensure_epmd() ->
-    {ok, Prog} = init:get_argument(progname),
+    {ok, [[Prog]]} = init:get_argument(progname),
+    Exe = os:find_executable(Prog),
+    do_ensure_epmd(Exe, Prog).
+
+do_ensure_epmd(false, Prog) ->
+    Path = os:getenv("PATH"),
+    rabbit_log:error("ensure_epmd: unable to find executable '~s' in PATH: '~s'", [Prog, Path]);
+do_ensure_epmd(Exe, _) ->
     ID = rabbit_misc:random(1000000000),
     Port = open_port(
-             {spawn_executable, os:find_executable(Prog)},
+             {spawn_executable, Exe},
              [{args, ["-sname", rabbit_misc:format("epmd-starter-~b", [ID]),
                       "-noshell", "-eval", "halt()."]},
               exit_status, stderr_to_stdout, use_stdio]),


### PR DESCRIPTION
Improves rabbitmq/rabbitmq-server#1654

Reported via:

https://groups.google.com/d/msg/rabbitmq-users/YgtY4R_heI0/AZFs5RPTCgAJ

VESC-906

Example output if `erl` can't be found. Tested via hard-coding the `Exe` argument to `do_ensure_epmd` to `"foofoobar"`:

```
2018-09-27 12:25:38.440 [error] <0.402.0> ensure_epmd: unable to find executable 'erl' in PATH: '/home/lbakken/development/erlang/installs/21.1/erts-10.1/bin:/home/lbakken/development/erlang/installs/21.1/bin:...'
```