### PR TITLE
Remove dependency on erlang-src

### DIFF
--- a/src/rabbit_net.erl
+++ b/src/rabbit_net.erl
@@ -18,7 +18,6 @@
 -include("rabbit.hrl").
 
 -include_lib("kernel/include/inet.hrl").
--include_lib("ssl/src/ssl_api.hrl").
 
 -export([is_ssl/1, ssl_info/1, controlling_process/2, getstat/2,
          recv/1, sync_recv/2, async_recv/3, port_command/2, getopts/2,
@@ -89,7 +88,9 @@
 
 -define(SSL_CLOSE_TIMEOUT, 5000).
 
--define(IS_SSL(Sock), is_record(Sock, sslsocket)).
+-define(IS_SSL(Sock), is_tuple(Sock)
+    andalso (tuple_size(Sock) =:= 3)
+    andalso (element(1, Sock) =:= sslsocket)).
 
 is_ssl(Sock) -> ?IS_SSL(Sock).
 


### PR DESCRIPTION
It has been reported that in order to use the Erlang client, the
Erlang/OTP source must be available. This is due to one include
file that rabbit_net required. This dependency has been removed.

Instead of calling is_record(sslsocket) the macro ?IS_SSL will
now perform the same test manually (check that it is a tuple,
that the size is correct and that the first element equals sslsocket).

The tuple has not changed in a very long time so doing this
manually is at least as safe as including this private header
file (it could be removed or moved at any time).

Once Erlang/OTP 22 gets out and we know how sockets will be
represented with the NIF implementation, we could revise this
and check whether the socket is one that gen_tcp accepts
(currently it's a port, but this will probably change when
a NIF is used).

Fixes https://github.com/rabbitmq/rabbitmq-common/issues/27 - this should remove a pain point for many people for using the Erlang client.

Tested against some of the rabbitmq-server test suites that deal with ssl (proxy_protocol is one).