### PR TITLE
rabbitmq-run.mk: Fix stop-brokers with NODES > 1

### DIFF
--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -341,7 +341,7 @@ start-brokers start-cluster:
 	done
 
 stop-brokers stop-cluster:
-	@for n in $$(seq $(NODES) 1); do \
+	@for n in $$(seq $(NODES) -1 1); do \
 		nodename="rabbit-$$n@$$(hostname -s)"; \
 		$(MAKE) stop-node \
 		  RABBITMQ_NODENAME="$$nodename"; \


### PR DESCRIPTION
Remove extra "1" in seq command.  Previously, as an example with
NODES=2, will run `seq 2 1` which produces no items to iterate, so the
entire stop-node loop does not execute and the brokers are left
running.

(This should qualify as an Obvious Fix for CLA purposes)