### PR TITLE
rabbit_backing_queue: extend is_duplicate callback return values

### DIFF
--- a/src/rabbit_backing_queue.erl
+++ b/src/rabbit_backing_queue.erl
@@ -255,9 +255,9 @@
 
 %% Called prior to a publish or publish_delivered call. Allows the BQ
 %% to signal that it's already seen this message, (e.g. it was published
-%% or discarded previously) and thus the message should be dropped.
+%% or discarded previously) specifying whether to drop the message or reject it.
 -callback is_duplicate(rabbit_types:basic_message(), state())
-                      -> {boolean(), state()}.
+                      -> {{true, drop} | {true, reject} | boolean(), state()}.
 
 -callback set_queue_mode(queue_mode(), state()) -> state().
 


### PR DESCRIPTION
Allow the backing queue implementation to instruct the amqqueue process
on how to proceed when a message duplicate is encountered.

 * {true, drop} the message is a duplicate and should be ignored
 * {true, reject} the message is a duplicate and the publisher should
   receive a rejection
 * false the message is not deemed a duplicate
 * true kept for backward compatibility, equivalent to {true, drop}

Signed-off-by: Matteo Cafasso <noxdafox@gmail.com>