### PR TITLE
Revert " Use RABBITMQ_QUORUM_DIR as ra data_dir when starting a node"

### DIFF
--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -64,7 +64,6 @@ node_pid_file = $(call node_tmpdir,$(1))/$(1).pid
 node_log_base = $(call node_tmpdir,$(1))/log
 node_mnesia_base = $(call node_tmpdir,$(1))/mnesia
 node_mnesia_dir = $(call node_mnesia_base,$(1))/$(1)
-node_quorum_dir = $(call node_mnesia_dir,$(1))/quorum
 node_schema_dir = $(call node_tmpdir,$(1))/schema
 node_plugins_expand_dir = $(call node_tmpdir,$(1))/plugins
 node_generated_config_dir = $(call node_tmpdir,$(1))/config
@@ -79,7 +78,6 @@ RABBITMQ_PID_FILE ?= $(call node_pid_file,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_LOG_BASE ?= $(call node_log_base,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_MNESIA_BASE ?= $(call node_mnesia_base,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_MNESIA_DIR ?= $(call node_mnesia_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
-RABBITMQ_QUORUM_DIR ?= $(call node_quorum_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_SCHEMA_DIR ?= $(call node_schema_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_PLUGINS_EXPAND_DIR ?= $(call node_plugins_expand_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_GENERATED_CONFIG_DIR ?= $(call node_generated_config_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
@@ -107,7 +105,6 @@ RABBITMQ_PID_FILE="$(call node_pid_file,$(2))" \
 RABBITMQ_LOG_BASE="$(call node_log_base,$(2))" \
 RABBITMQ_MNESIA_BASE="$(call node_mnesia_base,$(2))" \
 RABBITMQ_MNESIA_DIR="$(call node_mnesia_dir,$(2))" \
-RABBITMQ_QUORUM_DIR="$(call node_quorum_dir,$(2))" \
 RABBITMQ_SCHEMA_DIR="$(call node_schema_dir,$(2))" \
 RABBITMQ_GENERATED_CONFIG_DIR="$(call node_generated_config_dir,$(2))" \
 RABBITMQ_PLUGINS_DIR="$(RMQ_PLUGINS_DIR)" \
@@ -173,7 +170,7 @@ $(if $(RABBITMQ_NODE_PORT),      {listeners$(COMMA) [$(RABBITMQ_NODE_PORT)]}$(CO
 $(if $(RABBITMQ_NODE_PORT),      {listener$(COMMA) [{port$(COMMA) $(shell echo "$$(($(RABBITMQ_NODE_PORT) + 10000))")}]},)
     ]},
   {ra, [
-      {data_dir, "$(RABBITMQ_QUORUM_DIR)"}
+      {data_dir, "$(NODE_TMPDIR)"}
     ]}
 ].
 endef
@@ -207,7 +204,7 @@ define test_rabbitmq_config_with_tls
         ]}
   ]},
   {ra, [
-      {data_dir, "$(RABBITMQ_QUORUM_DIR)"}
+      {data_dir, "$(NODE_TMPDIR)"}
     ]}
 ].
 endef
@@ -325,7 +322,7 @@ start-brokers start-cluster:
 		  RABBITMQ_NODE_PORT="$$((5672 + $$n - 1))" \
 		  RABBITMQ_SERVER_START_ARGS=" \
 		  -rabbit loopback_users [] \
-		  -ra data_dir "$(RABBITMQ_QUORUM_DIR)"
+		  -ra data_dir "$(NODE_TMPDIR)"
 		  -rabbitmq_management listener [{port,$$((15672 + $$n - 1))}] \
 		  "; \
 		if test '$@' = 'start-cluster' && test "$$nodename1"; then \

--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -168,9 +168,6 @@ $(if $(RABBITMQ_NODE_PORT),      {listeners$(COMMA) [$(RABBITMQ_NODE_PORT)]}$(CO
     ]},
   {rabbitmq_management, [
 $(if $(RABBITMQ_NODE_PORT),      {listener$(COMMA) [{port$(COMMA) $(shell echo "$$(($(RABBITMQ_NODE_PORT) + 10000))")}]},)
-    ]},
-  {ra, [
-      {data_dir, "$(NODE_TMPDIR)"}
     ]}
 ].
 endef
@@ -202,10 +199,7 @@ define test_rabbitmq_config_with_tls
             {fail_if_no_peer_cert, false},
             {honor_cipher_order, true}]}
         ]}
-  ]},
-  {ra, [
-      {data_dir, "$(NODE_TMPDIR)"}
-    ]}
+  ]}
 ].
 endef
 
@@ -322,7 +316,6 @@ start-brokers start-cluster:
 		  RABBITMQ_NODE_PORT="$$((5672 + $$n - 1))" \
 		  RABBITMQ_SERVER_START_ARGS=" \
 		  -rabbit loopback_users [] \
-		  -ra data_dir "$(NODE_TMPDIR)"
 		  -rabbitmq_management listener [{port,$$((15672 + $$n - 1))}] \
 		  "; \
 		if test '$@' = 'start-cluster' && test "$$nodename1"; then \


### PR DESCRIPTION
This reverts commit 5bf9ae0726f1ca6087986be1d616335bddd81f94.

[#161508487]