### PR TITLE
Be more defensive when requesting connection parameters

### DIFF
--- a/src/rabbit_amqp_connection.erl
+++ b/src/rabbit_amqp_connection.erl
@@ -23,15 +23,19 @@ amqp_params(ConnPid, Timeout) ->
     P = try
             gen_server:call(ConnPid, {info, [amqp_params]}, Timeout)
         catch exit:{noproc, Error} ->
-            rabbit_log:debug("file ~p, line ~p - connection process ~p not alive: ~p~n",
-                             [?FILE, ?LINE, ConnPid, Error]),
+                rabbit_log:debug("file ~p, line ~p - connection process ~p not alive: ~p~n",
+                                 [?FILE, ?LINE, ConnPid, Error]),
+            [];
+              _:Error ->
+                rabbit_log:debug("file ~p, line ~p - failed to get amqp_params from connection process ~p: ~p~n",
+                                 [?FILE, ?LINE, ConnPid, Error]),
             []
         end,
     process_amqp_params_result(P).
 
 process_amqp_params_result({error, {bad_argument, amqp_params}}) ->
-    % Some connection process modules do not handle the {info, [amqp_params]}
-    % message (like rabbit_reader) and throw a bad_argument error
+    %% Some connection process modules do not handle the {info, [amqp_params]}
+    %% message (like rabbit_reader) and throw a bad_argument error
     [];
 process_amqp_params_result({ok, AmqpParams}) ->
     AmqpParams;


### PR DESCRIPTION
A continuation to rabbitmq/rabbitmq-server#1538.

Some users on the mailing list report stacktraces similar to what rabbitmq/rabbitmq-server#1538 addressed. Looks like in those cases the connection terminates normally, which the code in question did not handle. If we can't retrieve connection parameters, assume they are blank instead of failing with an exception.