### PR TITLE
Ensure first heartbeat frame is sent to clients at expected interval

### DIFF
--- a/src/rabbit_heartbeat.erl
+++ b/src/rabbit_heartbeat.erl
@@ -144,7 +144,13 @@ heartbeater({Sock, TimeoutMillisec, StatName, Threshold, Handler} = Params,
             exit({unexpected_message, Other})
     after TimeoutMillisec ->
               OkFun = fun(StatVal1) ->
-                              if StatVal1 =/= StatVal0 ->
+                              if StatVal0 =:= 0 andalso StatName =:= send_oct ->
+                                     % Note: this clause is necessary to ensure the
+                                     % first RMQ -> client heartbeat is sent at the
+                                     % first interval, instead of waiting the first
+                                     % two intervals
+                                     {run_handler, {StatVal1, 0}};
+                                 StatVal1 =/= StatVal0 ->
                                      {recurse, {StatVal1, 0}};
                                  SameCount < Threshold ->
                                      {recurse, {StatVal1, SameCount +1}};


### PR DESCRIPTION
If the negotiated heartbeat timeout is 10 seconds, this will ensure the first frame is sent at 5 seconds. Previously it took two intervals (10 seconds total) to discover a difference in the `send_oct` value, which would trigger a heartbeat.