### PR TITLE
Fix many Dialyzer warnings

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -202,8 +202,9 @@
 -spec node_to_fake_pid(atom()) -> pid().
 -spec version_compare(string(), string()) -> 'lt' | 'eq' | 'gt'.
 -spec version_compare
-        (string(), string(), ('lt' | 'lte' | 'eq' | 'gte' | 'gt')) -> boolean().
--spec version_minor_equivalent(string(), string()) -> boolean().
+        (rabbit_semver:version_string(), rabbit_semver:version_string(),
+         ('lt' | 'lte' | 'eq' | 'gte' | 'gt')) -> boolean().
+-spec version_minor_equivalent(rabbit_semver:version_string(), rabbit_semver:version_string()) -> boolean().
 -spec dict_cons(any(), any(), dict:dict()) -> dict:dict().
 -spec orddict_cons(any(), any(), orddict:orddict()) -> orddict:orddict().
 -spec gb_trees_cons(any(), any(), gb_trees:tree()) -> gb_trees:tree().

--- a/src/rabbit_pbe.erl
+++ b/src/rabbit_pbe.erl
@@ -174,7 +174,7 @@ block_size(_) -> 8.
 %% These functions have been copied here to stay compatible with R16B03.
 
 %%--------------------------------------------------------------------
--spec pbdkdf2(string(), iodata(), integer(), integer(), fun(), atom(), integer())
+-spec pbdkdf2(iodata(), iodata(), integer(), integer(), fun(), atom(), integer())
 	     -> binary().
 %%
 %% Description: Implements password based decryption key derive function 2.


### PR DESCRIPTION
They trigger warnings in rabbit. This can be merged independently of the upcoming rabbit PR.