### PR TITLE
Add lager sink for ldap

### DIFF
--- a/mk/rabbitmq-build.mk
+++ b/mk/rabbitmq-build.mk
@@ -39,7 +39,7 @@ endif
 LAGER_EXTRA_SINKS += rabbit_log \
 		     rabbit_log_channel \
 		     rabbit_log_connection \
-    	     rabbit_log_ldap \
+		     rabbit_log_ldap \
 		     rabbit_log_mirroring \
 		     rabbit_log_queue \
 		     rabbit_log_ra \

--- a/mk/rabbitmq-build.mk
+++ b/mk/rabbitmq-build.mk
@@ -39,6 +39,7 @@ endif
 LAGER_EXTRA_SINKS += rabbit_log \
 		     rabbit_log_channel \
 		     rabbit_log_connection \
+    	     rabbit_log_ldap \
 		     rabbit_log_mirroring \
 		     rabbit_log_queue \
 		     rabbit_log_ra \

--- a/src/rabbit_log.erl
+++ b/src/rabbit_log.erl
@@ -76,6 +76,7 @@ log(Category, Level, Fmt, Args) when is_list(Args) ->
 
 make_internal_sink_name(connection) -> rabbit_log_connection_lager_event;
 make_internal_sink_name(channel)    -> rabbit_log_channel_lager_event;
+make_internal_sink_name(ldap)       -> rabbit_log_ldap_lager_event;
 make_internal_sink_name(mirroring)  -> rabbit_log_mirroring_lager_event;
 make_internal_sink_name(queue)      -> rabbit_log_queue_lager_event;
 make_internal_sink_name(federation) -> rabbit_log_federation_lager_event;


### PR DESCRIPTION
Add new external sink to able log LDAP message to different file.

This is a part of rabbitmq/rabbitmq-auth-backend-ldap#105.