### PR TITLE
Make rabbit_pbe work for OTP-22

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -114,6 +114,12 @@
 %%
 -module(gen_server2).
 
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 22).
+-compile(nowarn_deprecated_function).
+-endif.
+-endif.
+
 %%% ---------------------------------------------------
 %%%
 %%% The idea behind THIS server is that the user module


### PR DESCRIPTION
This depends on https://github.com/erlang/otp/pull/2186 so should not be merged yet.

A good cleanup of this module should be planned once we support OTP-22+. We can remove more than half of the module when that happens.