### PR TITLE
vm_memory_monitor: handle KB as well as kB

### DIFF
--- a/src/vm_memory_monitor.erl
+++ b/src/vm_memory_monitor.erl
@@ -519,7 +519,8 @@ parse_line_linux(Line) ->
         end,
     Value1 = case UnitRest of
         []     -> list_to_integer(Value); %% no units
-        ["kB"] -> list_to_integer(Value) * 1024
+        ["kB"] -> list_to_integer(Value) * 1024;
+        ["KB"] -> list_to_integer(Value) * 1024
     end,
     {list_to_atom(Name), Value1}.
 


### PR DESCRIPTION
There are cases (e.g. inside LXC) where the unit reported in /proc/meminfo uses
KB instead of kB. Handle this case.