### PR TITLE
rabbit_misc: Generate a `NEW_PID_EXT`-based binary in compose_pid/4

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -726,7 +726,7 @@ decompose_pid(Pid) when is_pid(Pid) ->
 
 compose_pid(Node, Cre, Id, Ser) ->
     <<131,NodeEnc/binary>> = term_to_binary(Node),
-    binary_to_term(<<131,103,NodeEnc/binary,Id:32,Ser:32,Cre:8>>).
+    binary_to_term(<<131,88,NodeEnc/binary,Id:32,Ser:32,Cre:32>>).
 
 version_compare(A, B, eq)  -> rabbit_semver:eql(A, B);
 version_compare(A, B, lt)  -> rabbit_semver:lt(A, B);


### PR DESCRIPTION
The `creation` field might not fit into one byte which makes the `PID_EXT` format unsuitable for this case.

The `NEW_PID_EXT` format is supported since Erlang 19.0, so it is safe to always use it, no matter the value of `creation`, because RabbitMQ 3.7+ requires at least Erlang 19.3+.

References #313.