### PR TITLE
rabbit_ssl_options: Blacklist TLS 1.3 until Erlang client implementation is finished

### DIFF
--- a/src/rabbit_ssl_options.erl
+++ b/src/rabbit_ssl_options.erl
@@ -18,8 +18,22 @@
 
 -export([fix/1]).
 
-%% POODLE
--define(BAD_SSL_PROTOCOL_VERSIONS, [sslv3]).
+
+-define(BAD_SSL_PROTOCOL_VERSIONS, [
+                                    %% POODLE
+                                    sslv3,
+
+                                    %% Client side of TLS 1.3 is not yet
+                                    %% implemented in Erlang/OTP 22.0
+                                    %% prereleases. As a consequence,
+                                    %% not sure about the stability of
+                                    %% the server side.
+                                    %%
+                                    %% FIXME: Revisit this decision when
+                                    %% Erlang/OTP 22.0 final release is
+                                    %% out.
+                                    'tlsv1.3'
+                                   ]).
 
 -spec fix(rabbit_types:infos()) -> rabbit_types:infos().
 


### PR DESCRIPTION
Erlang 22 will introduce TLS 1.3, but at the time of this commit, only the server side is implemented. If the Erlang client requests TLS 1.3, the server will accept but the client will either hang or crash.

So for now, just blacklist TLS 1.3 to avoid any issues, even on the server side, just to be safe.

This should be backported to `v3.7.x` if accepted.

[#165214130]