### PR TITLE
Backport RabbitMQ compatible versions check

### DIFF
--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -67,6 +67,7 @@ node_mnesia_dir = $(call node_mnesia_base,$(1))/$(1)
 node_schema_dir = $(call node_tmpdir,$(1))/schema
 node_plugins_expand_dir = $(call node_tmpdir,$(1))/plugins
 node_generated_config_dir = $(call node_tmpdir,$(1))/config
+node_feature_flags_file = $(call node_tmpdir,$(1))/feature_flags
 node_enabled_plugins_file = $(call node_tmpdir,$(1))/enabled_plugins
 
 # Broker startup variables for the test environment.
@@ -81,6 +82,7 @@ RABBITMQ_MNESIA_DIR ?= $(call node_mnesia_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_SCHEMA_DIR ?= $(call node_schema_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_PLUGINS_EXPAND_DIR ?= $(call node_plugins_expand_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_GENERATED_CONFIG_DIR ?= $(call node_generated_config_dir,$(RABBITMQ_NODENAME_FOR_PATHS))
+RABBITMQ_FEATURE_FLAGS_FILE ?= $(call node_feature_flags_file,$(RABBITMQ_NODENAME_FOR_PATHS))
 RABBITMQ_ENABLED_PLUGINS_FILE ?= $(call node_enabled_plugins_file,$(RABBITMQ_NODENAME_FOR_PATHS))
 
 # erlang.mk adds dependencies' ebin directory to ERL_LIBS. This is
@@ -107,6 +109,7 @@ RABBITMQ_MNESIA_BASE="$(call node_mnesia_base,$(2))" \
 RABBITMQ_MNESIA_DIR="$(call node_mnesia_dir,$(2))" \
 RABBITMQ_SCHEMA_DIR="$(call node_schema_dir,$(2))" \
 RABBITMQ_GENERATED_CONFIG_DIR="$(call node_generated_config_dir,$(2))" \
+RABBITMQ_FEATURE_FLAGS_FILE="$(call node_feature_flags_file,$(2))" \
 RABBITMQ_PLUGINS_DIR="$(RMQ_PLUGINS_DIR)" \
 RABBITMQ_PLUGINS_EXPAND_DIR="$(call node_plugins_expand_dir,$(2))" \
 RABBITMQ_SERVER_START_ARGS="$(RABBITMQ_SERVER_START_ARGS)"

--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -150,10 +150,15 @@ ifeq ($(wildcard ebin/test),)
 $(RABBITMQ_ENABLED_PLUGINS_FILE): dist
 endif
 
+ifdef LEAVE_PLUGINS_DISABLED
+$(RABBITMQ_ENABLED_PLUGINS_FILE): node-tmpdir
+	$(gen_verbose) : >$@
+else
 $(RABBITMQ_ENABLED_PLUGINS_FILE): node-tmpdir
 	$(verbose) rm -f $@
 	$(gen_verbose) $(BASIC_SCRIPT_ENV_SETTINGS) \
 	  $(RABBITMQ_PLUGINS) enable --all --offline
+endif
 
 # --------------------------------------------------------------------
 # Run a full RabbitMQ.

--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -167,7 +167,8 @@ define test_rabbitmq_config
 [
   {rabbit, [
 $(if $(RABBITMQ_NODE_PORT),      {listeners$(COMMA) [$(RABBITMQ_NODE_PORT)]}$(COMMA),)
-      {loopback_users, []}
+      {loopback_users, []},
+      {log, [{file, [{level, debug}]}]}
     ]},
   {rabbitmq_management, [
 $(if $(RABBITMQ_NODE_PORT),      {listener$(COMMA) [{port$(COMMA) $(shell echo "$$(($(RABBITMQ_NODE_PORT) + 10000))")}]},)
@@ -181,6 +182,7 @@ define test_rabbitmq_config_with_tls
 [
   {rabbit, [
       {loopback_users, []},
+      {log, [{file, [{level, debug}]}]},
       {ssl_listeners, [5671]},
       {ssl_options, [
           {cacertfile, "$(TEST_TLS_CERTS_DIR_in_config)/testca/cacert.pem"},

--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -110,7 +110,7 @@ RABBITMQ_MNESIA_DIR="$(call node_mnesia_dir,$(2))" \
 RABBITMQ_SCHEMA_DIR="$(call node_schema_dir,$(2))" \
 RABBITMQ_GENERATED_CONFIG_DIR="$(call node_generated_config_dir,$(2))" \
 RABBITMQ_FEATURE_FLAGS_FILE="$(call node_feature_flags_file,$(2))" \
-RABBITMQ_PLUGINS_DIR="$(RMQ_PLUGINS_DIR)" \
+RABBITMQ_PLUGINS_DIR="$(if $(RABBITMQ_PLUGINS_DIR),$(RABBITMQ_PLUGINS_DIR),$(RMQ_PLUGINS_DIR))" \
 RABBITMQ_PLUGINS_EXPAND_DIR="$(call node_plugins_expand_dir,$(2))" \
 RABBITMQ_SERVER_START_ARGS="$(RABBITMQ_SERVER_START_ARGS)"
 endef

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -42,8 +42,6 @@ groups() ->
             encrypt_decrypt,
             encrypt_decrypt_term,
             version_equivalence,
-            version_minor_equivalence_properties,
-            version_comparison,
             pid_decompose_compose,
             platform_and_version,
             frame_encoding_does_not_fail_with_empty_binary_payload
@@ -392,6 +390,13 @@ version_equivalence(_Config) ->
     false = rabbit_misc:version_minor_equivalent("3.6.6", "3.7.0"),
     true = rabbit_misc:version_minor_equivalent("3.6.7", "3.6.6"),
 
+    %% Starting with RabbitMQ 3.7.x and feature flags introduced in
+    %% RabbitMQ 3.8.x, versions are considered equivalent and the actual
+    %% check is deferred to the feature flags module.
+    false = rabbit_misc:version_minor_equivalent("3.6.0", "3.8.0"),
+    true = rabbit_misc:version_minor_equivalent("3.7.0", "3.8.0"),
+    true = rabbit_misc:version_minor_equivalent("3.7.0", "3.10.0"),
+
     true = rabbit_misc:version_minor_equivalent(<<"3.0.0">>, <<"3.0.0">>),
     true = rabbit_misc:version_minor_equivalent(<<"3.0.0">>, <<"3.0.1">>),
     true = rabbit_misc:version_minor_equivalent(<<"%%VSN%%">>, <<"%%VSN%%">>),
@@ -399,176 +404,6 @@ version_equivalence(_Config) ->
     true = rabbit_misc:version_minor_equivalent(<<"3.0.0">>, <<"3.0.0.1">>),
     false = rabbit_misc:version_minor_equivalent(<<"3.0.0">>, <<"3.1.0">>),
     false = rabbit_misc:version_minor_equivalent(<<"3.0.0.1">>, <<"3.1.0.1">>).
-
-version_minor_equivalence_properties(_Config) ->
-    true = proper:counterexample(
-             ?FORALL(
-                {A, B},
-                {version(), version()},
-                check_minor_equivalent(A, B)
-               ),
-             [
-              quiet,
-              {numtests, 10000},
-              {on_output, fun(F, A) -> ct:pal(?LOW_IMPORTANCE, F, A) end}
-             ]
-            ).
-
-version_comparison(_Config) ->
-    true = proper:counterexample(
-             ?FORALL(
-                {A, B},
-                {version(), version()},
-                check_and_compare_versions(A, B)
-               ),
-             [
-              quiet,
-              {numtests, 10000},
-              {on_output, fun(F, A) -> ct:pal(?LOW_IMPORTANCE, F, A) end}
-             ]
-            ).
-
-version() ->
-    union([
-           [],
-           release(),
-           prerelease()
-          ]).
-
-release() ->
-    union([
-           identifier(),
-           [non_neg_integer()],
-           [non_neg_integer(), ".", 0],
-           [non_neg_integer(), ".", frequency([{1, 0}, {1, pos_integer()}])],
-           [non_neg_integer(), ".", non_neg_integer(), ".", frequency([{1, 0}, {1, pos_integer()}])]
-          ]).
-
-prerelease() ->
-    {release(), "-", identifier()}.
-
-identifier() ->
-    union(
-      [[identifier_first_char()],
-       non_empty(list(identifier_char()))]
-     ).
-
-identifier_first_char() ->
-    union([non_zero_digit(), uppercase(), lowercase()]).
-
-%% FIXME: We should have $- as a valid identifier_char(), but the
-%% rabbit_semver library doesn't support having a dash as the last
-%% character in an identifier. For now, do not use dashes in an
-%% identifier. We could probably fix the property to only generate dash
-%% as the non-first non-last character.
-identifier_char() ->
-    union([digit(), uppercase(), lowercase()]).
-
-digit()          -> integer(48, 57).
-non_zero_digit() -> integer(49, 57).
-uppercase()      -> integer(65, 90).
-lowercase()      -> integer(97, 122).
-
-check_minor_equivalent({Release, Sep, Extra}, B) ->
-    A = Release ++ [Sep, Extra],
-    check_minor_equivalent(A, B);
-check_minor_equivalent(A, {Release, Sep, Extra}) ->
-    B = Release ++ [Sep, Extra],
-    check_minor_equivalent(A, B);
-
-check_minor_equivalent([], []) ->
-    check_minor_equivalent([], [], true);
-check_minor_equivalent([Maj, ".", 0 | _] = A, [Maj] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-check_minor_equivalent([Maj, ".", 0 | _] = A, [Maj, "-", _ | _] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-
-check_minor_equivalent([Maj] = A, [Maj, ".", 0 | _] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-check_minor_equivalent([Maj, "-", _ | _] = A, [Maj, ".", 0 | _] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-
-check_minor_equivalent([Maj, ".", 0 | _] = A, [Maj, ".", 0 | _] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-
-check_minor_equivalent([Maj] = A, [Maj] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-check_minor_equivalent([Maj, "-", _ | _] = A, [Maj] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-check_minor_equivalent([Maj] = A, [Maj, "-", _ | _] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-check_minor_equivalent([Maj, "-", _ | _] = A, [Maj, "-", _ | _] = B)
-  when is_integer(Maj) ->
-    check_minor_equivalent(A, B, true);
-
-check_minor_equivalent([3, ".", 6, ".", PatchA | _] = A, [3, ".", 6, ".", PatchB | _] = B)
-  when is_integer(PatchA) andalso is_integer(PatchB) ->
-    Expected = if
-                   PatchA >= 6 -> PatchB >= 6;
-                   PatchA < 6  -> PatchB < 6;
-                   true -> false
-               end,
-    check_minor_equivalent(A, B, Expected);
-
-check_minor_equivalent([Maj, ".", Min | _] = A, [Maj, ".", Min | _] = B)
-  when is_integer(Maj) andalso is_integer(Min) ->
-    check_minor_equivalent(A, B, true);
-
-check_minor_equivalent(A, B) ->
-    check_minor_equivalent(A, B, false).
-
-check_minor_equivalent(RawA, RawB, Expected) ->
-    A = lists:flatten([raw_to_string(Char) || Char <- RawA]),
-    B = lists:flatten([raw_to_string(Char) || Char <- RawB]),
-    Expected =:= rabbit_misc:version_minor_equivalent(A, B).
-
-check_and_compare_versions({Release, Sep, Extra}, B) ->
-    A = Release ++ [Sep, Extra],
-    check_and_compare_versions(A, B);
-check_and_compare_versions(A, {Release, Sep, Extra}) ->
-    B = Release ++ [Sep, Extra],
-    check_and_compare_versions(A, B);
-check_and_compare_versions(RawA, RawB) ->
-    A = lists:flatten([raw_to_string(Char) || Char <- RawA]),
-    B = lists:flatten([raw_to_string(Char) || Char <- RawB]),
-    Result1 = rabbit_misc:version_compare(A, B),
-    Result2 = rabbit_misc:version_compare(B, A),
-    case {Result1, Result2} of
-        {lt, gt} ->
-            true =:= rabbit_misc:version_compare(A, B, lte) andalso
-            false =:= rabbit_misc:version_compare(A, B, gte) andalso
-            false =:= rabbit_misc:version_compare(A, B, eq);
-        {gt, lt} ->
-            true =:= rabbit_misc:version_compare(A, B, gte) andalso
-            false =:= rabbit_misc:version_compare(A, B, lte) andalso
-            false =:= rabbit_misc:version_compare(A, B, eq);
-        {eq, eq} ->
-            true =:= rabbit_misc:version_compare(A, B, gte) andalso
-            true =:= rabbit_misc:version_compare(A, B, lte) andalso
-            true =:= rabbit_misc:version_compare(A, B, eq);
-        _ ->
-            ct:pal(
-              "rabbit_misc:version_compare/2 failure:~n"
-              "A: ~p~n"
-              "B: ~p~n"
-              "Result1: ~p~n"
-              "Result2: ~p~n", [A, B, Result1, Result2]),
-            false
-    end.
-
-raw_to_string(Char)
-  when is_integer(Char) ->
-    integer_to_list(Char);
-raw_to_string(Char) ->
-    Char.
 
 set_stats_interval(Interval) ->
     application:set_env(rabbit, collect_statistics, coarse),


### PR DESCRIPTION
The version check is relaxed. The real check is now made by the feature flags subsystem.

References rabbitmq/rabbitmq-server#2028.