### PR TITLE
Add stop{1,3} functions to gen_server2

### DIFF
--- a/src/gen_server2.erl
+++ b/src/gen_server2.erl
@@ -204,6 +204,7 @@
 %% API
 -export([start/3, start/4,
          start_link/3, start_link/4,
+         stop/1, stop/3,
          call/2, call/3,
          cast/2, reply/2,
          abcast/2, abcast/3,
@@ -311,6 +312,16 @@ start_link(Mod, Args, Options) ->
 start_link(Name, Mod, Args, Options) ->
     gen:start(?MODULE, link, Name, Mod, Args, Options).
 
+%% -----------------------------------------------------------------
+%% Stop a generic server and wait for it to terminate.
+%% If the server is located at another node, that node will
+%% be monitored.
+%% -----------------------------------------------------------------
+stop(Name) ->
+    gen:stop(Name).
+
+stop(Name, Reason, Timeout) ->
+    gen:stop(Name, Reason, Timeout).
 
 %% -----------------------------------------------------------------
 %% Make a call to a generic server.

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -57,7 +57,8 @@ groups() ->
             stats_timer_writes_gen_server2_metrics_if_core_metrics_ets_exists,
             stop_stats_timer_on_hibernation,
             stop_stats_timer_on_backoff,
-            stop_stats_timer_on_backoff_when_backoff_less_than_stats_timeout
+            stop_stats_timer_on_backoff_when_backoff_less_than_stats_timeout,
+            gen_server2_stop
         ]}
     ].
 
@@ -235,6 +236,13 @@ stop_stats_timer_on_backoff_when_backoff_less_than_stats_timeout(_) ->
     timer:sleep(StatsInterval * 4 + 100),
     StatsCount5 = gen_server2_test_server:stats_count(TestServer),
     5 = StatsCount5.
+
+gen_server2_stop(_) ->
+    {ok, TestServer} = gen_server2_test_server:start_link(),
+    ok = gen_server2:stop(TestServer),
+    false = erlang:is_process_alive(TestServer),
+    {'EXIT',noproc} = (catch gen_server:stop(TestServer)),
+    ok.
 
 parse_mem_limit_relative_exactly_max(_Config) ->
     MemLimit = vm_memory_monitor:parse_mem_limit(1.0),


### PR DESCRIPTION
These functions utilize proc_lib:stop, which in turn utilizes sys:terminate.

They were introduced in
https://github.com/erlang/otp/commit/9d7d1207ff1240b9711f192deb0893c3a044a3d8.

Closes: #266