### PR TITLE
add forgotten ldap type

### DIFF
--- a/src/rabbit_log.erl
+++ b/src/rabbit_log.erl
@@ -31,7 +31,7 @@
 -include("rabbit_log.hrl").
 %%----------------------------------------------------------------------------
 
--type category() :: connection | channel | mirroring | queue | federation | upgrade | ra.
+-type category() :: connection | channel | ldap | mirroring | queue | federation | upgrade | ra.
 
 -spec debug(string()) -> 'ok'.
 -spec debug(string(), [any()]) -> 'ok'.


### PR DESCRIPTION
There is ldap sink name, but when I made a PR that added this sink I forgot to add it to category()