### PR TITLE
Fix wrong list operation in 'delegate:invoke'

### DIFF
--- a/src/delegate.erl
+++ b/src/delegate.erl
@@ -125,7 +125,7 @@ invoke(Pids, Name, FunOrMFA) when is_list(Pids) ->
     BadPids = [{Pid, {exit, {nodedown, BadNode}, []}} ||
                   BadNode <- BadNodes,
                   Pid     <- maps:get(BadNode, Grouped)],
-    ResultsNoNode = lists:append([safe_invoke(LocalPids, FunOrMFA) |
+    ResultsNoNode = lists:append([safe_invoke(LocalPids, FunOrMFA) ,
                                   [Results || {_Node, Results} <- Replies]]),
     lists:foldl(
       fun ({ok,    Pid, Result}, {Good, Bad}) -> {[{Pid, Result} | Good], Bad};


### PR DESCRIPTION
In 'delegate:invoke', safe_invoke(LocalPids, FunOrMFA) returns a list, and [Results || {_Node, Results} <- Replies] is also a list, The 'lists:append/1' returns a list in which all the sublists of ListOfLists have been appended.

Please use the following code to verify:
test() ->
    X = [1,2],
    Y = [3,4],
    lists:append([X,Y]). 
    %% return  [1,2,3,4]. 
    %% lists:append([X | Y]) will raise a exception:
    %% ** exception error: bad argument
    %% in operator  ++/2
    %%    called as 3 ++ 4
    %% in call from lists:append/1 (lists.erl, line 127)
    %% in call from lists:append/1 (lists.erl, line 127)