### PR TITLE
To alarm when the Erlang process memory is greater than the free memory

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -86,6 +86,7 @@
 -export([report_default_thread_pool_size/0]).
 -export([get_gc_info/1]).
 -export([group_proplists_by/2]).
+-export([try_do/1, try_do/2]).
 
 %% Horrible macro to use in guards
 -define(IS_BENIGN_EXIT(R),
@@ -269,6 +270,8 @@
 -spec get_gc_info(pid()) -> [any()].
 -spec group_proplists_by(fun((proplists:proplist()) -> any()),
                          list(proplists:proplist())) -> list(list(proplists:proplist())).
+-spec try_do(thunk(A)) -> A.
+-spec try_do(thunk(A), thunk(A)) -> A.                        
 
 
 %%----------------------------------------------------------------------------
@@ -1415,6 +1418,21 @@ whereis_name(Name) ->
             end;
         [] -> undefined
     end.
+
+try_do(Thunk) ->
+    try 
+        Thunk()
+    catch _Class:_Reason:_Stacktrace ->
+        ok
+    end.
+
+try_do(ErrorHandler, Thunk) ->
+    try 
+        Thunk()
+    catch Class:Reason:Stacktrace ->
+        ErrorHandler({Class, Reason, Stacktrace})
+    end.
+
 
 %% End copypasta from gen_server2.erl
 %% -------------------------------------------------------------------------


### PR DESCRIPTION
%% In practice Erlang shouldn't be allowed to grow to more than a half
%% of available memory. The pessimistic scenario is when the Erlang VM
%% has a single process that's consuming all memory. In such a case,
%% during garbage collection, Erlang tries to allocate a huge chunk of
%% continuous memory, which can result in a crash or heavy swapping.
Copied from vm_memory_monitor.erl

So if memory the Erlang process consumed is greater than the free memory of the OS, the Erlang
GC might not work.

The PR only deals with the Linux OS at present.