### PR TITLE
rabbit_env: Record variables' origin

### DIFF
--- a/mk/rabbitmq-dist.mk
+++ b/mk/rabbitmq-dist.mk
@@ -257,7 +257,9 @@ do-dist:: $(DIST_EZS)
 		$(wildcard $(DIST_DIR)/*))'; \
 	test -z "$$unwanted" || (echo " RM     $$unwanted" && rm -rf $$unwanted)
 
+ifneq ($(PROJECT),rabbit_common)
 test-build:: install-cli
+endif
 
 CLI_SCRIPTS_LOCK = $(CLI_SCRIPTS_DIR).lock
 CLI_ESCRIPTS_LOCK = $(CLI_ESCRIPTS_DIR).lock

--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -140,9 +140,9 @@ virgin-node-tmpdir:
 .PHONY: test-tmpdir virgin-test-tmpdir node-tmpdir virgin-node-tmpdir
 
 ifdef LEAVE_PLUGINS_DISABLED
-RABBITMQ_ENABLED_PLUGINS = NONE
+RABBITMQ_ENABLED_PLUGINS ?=
 else
-RABBITMQ_ENABLED_PLUGINS = ALL
+RABBITMQ_ENABLED_PLUGINS ?= ALL
 endif
 
 # --------------------------------------------------------------------

--- a/src/rabbit_env.erl
+++ b/src/rabbit_env.erl
@@ -931,7 +931,7 @@ log_feature_flags_registry(Context) ->
 %%   List of plugins to enable on startup.
 %%   Values are:
 %%     "ALL" to enable all plugins
-%%     "NONE" to enable no plugin
+%%     "" to enable no plugin
 %%     a list of plugin names, separated by a coma (',')
 %%   Default: Empty (i.e. use ${RABBITMQ_ENABLED_PLUGINS_FILE})
 
@@ -1074,14 +1074,17 @@ enabled_plugins_file_from_node(#{from_remote_node := Remote} = Context) ->
     end.
 
 enabled_plugins(Context) ->
-    case get_prefixed_env_var("RABBITMQ_ENABLED_PLUGINS") of
+    Value = get_prefixed_env_var(
+              "RABBITMQ_ENABLED_PLUGINS",
+              [keep_empty_string_as_is]),
+    case Value of
         false ->
             update_context(Context, enabled_plugins, undefined, default);
         "ALL" ->
             update_context(Context, enabled_plugins, all, environment);
-        "NONE" ->
+        "" ->
             update_context(Context, enabled_plugins, [], environment);
-        Value ->
+        _ ->
             Plugins = [list_to_atom(P) || P <- string:lexemes(Value, ",")],
             update_context(Context, enabled_plugins, Plugins, environment)
     end.

--- a/src/rabbit_env.erl
+++ b/src/rabbit_env.erl
@@ -1343,8 +1343,6 @@ var_is_set(Var) ->
 value_is_yes(Value) when is_list(Value) orelse is_binary(Value) ->
     Options = [{capture, none}, caseless],
     re:run(string:trim(Value), "^(1|yes|true)$", Options) =:= match;
-value_is_yes(Value) when is_boolean(Value) ->
-    Value;
 value_is_yes(_) ->
     false.
 

--- a/src/rabbit_env.erl
+++ b/src/rabbit_env.erl
@@ -1524,10 +1524,7 @@ maybe_setup_dist_for_remote_query(
 maybe_setup_dist_for_remote_query(
   #{from_remote_node := {RemoteNode, _}} = Context) ->
     {NamePart, HostPart} = rabbit_nodes_common:parts(RemoteNode),
-    NameType = case string:find(HostPart, ".") of
-                   nomatch -> shortnames;
-                   _       -> longnames
-               end,
+    NameType = rabbit_nodes_common:name_type(RemoteNode),
     ok = rabbit_nodes_common:ensure_epmd(),
     Context1 = setup_dist_for_remote_query(
                  Context, NamePart, HostPart, NameType, 50),

--- a/src/rabbit_nodes_common.erl
+++ b/src/rabbit_nodes_common.erl
@@ -26,7 +26,7 @@
 %% API
 %%
 
--export([make/1, parts/1, names/1, ensure_epmd/0, is_running/2, is_process_running/2]).
+-export([make/1, parts/1, names/1, name_type/1, ensure_epmd/0, is_running/2, is_process_running/2]).
 -export([cookie_hash/0, epmd_port/0, diagnostics/1]).
 
 -spec make({string(), string()} | string()) -> node().
@@ -62,6 +62,13 @@ parts(NodeStr) ->
         {Prefix, []}     -> {_, Suffix} = parts(node()),
                             {Prefix, Suffix};
         {Prefix, Suffix} -> {Prefix, tl(Suffix)}
+    end.
+
+name_type(Node) ->
+    {_, HostPart} = parts(Node),
+    case lists:member($., HostPart) of
+        false -> shortnames;
+        true  -> longnames
     end.
 
 epmd_port() ->

--- a/test/rabbit_env_SUITE.erl
+++ b/test/rabbit_env_SUITE.erl
@@ -648,6 +648,11 @@ check_RABBITMQ_ENABLED_PLUGINS(_) ->
     check_prefixed_variable("RABBITMQ_ENABLED_PLUGINS",
                             enabled_plugins,
                             '_',
+                            "", [],
+                            "", []),
+    check_prefixed_variable("RABBITMQ_ENABLED_PLUGINS",
+                            enabled_plugins,
+                            '_',
                             rabbit_misc:format("~s,~s", Value1), Value1,
                             rabbit_misc:format("~s,~s", Value2), Value2).
 

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -45,7 +45,8 @@ groups() ->
             pid_decompose_compose,
             platform_and_version,
             frame_encoding_does_not_fail_with_empty_binary_payload,
-            amqp_table_conversion
+            amqp_table_conversion,
+            name_type
         ]},
         {parse_mem_limit, [parallel], [
             parse_mem_limit_relative_exactly_max,
@@ -435,3 +436,9 @@ set_stats_interval(Interval) ->
 reset_stats_interval() ->
     application:unset_env(rabbit, collect_statistics),
     application:unset_env(rabbit, collect_statistics_interval).
+
+name_type(_) ->
+    ?assertEqual(shortnames, rabbit_nodes_common:name_type(rabbit)),
+    ?assertEqual(shortnames, rabbit_nodes_common:name_type(rabbit@localhost)),
+    ?assertEqual(longnames, rabbit_nodes_common:name_type('rabbit@localhost.example.com')),
+    ok.


### PR DESCRIPTION
I.e. we record the fact that a particular value:
  * is the default value, or
  * comes from an environment variable, or
  * comes from querying a remote node

This required a significant refactoring of the module, which explains the large diff.

At the same time, the testsuite was extended to cover more code and situations.

This work permits us to move remaining environment variables checked by `rabbit` to this module. They include:
  * `$RABBITMQ_LOG_FF_REGISTRY`
  * `$RABBITMQ_FEATURE_FLAGS`
  * `$NOTIFY_SOCKET`

References rabbitmq/rabbitmq-server#2180.