### PR TITLE
Remove systemd_notify_socket

### DIFF
--- a/src/rabbit_env.erl
+++ b/src/rabbit_env.erl
@@ -115,7 +115,6 @@ get_context_after_reloading_env(Context) ->
              fun nodename_type/1,
              fun nodename/1,
              fun split_nodename/1,
-             fun systemd_notify_socket/1,
              fun maybe_setup_dist_for_remote_query/1,
              fun dbg_config/1,
              fun main_config_file/1,
@@ -1145,21 +1144,6 @@ erlang_dist_tcp_port(#{amqp_tcp_port := AmqpTcpPort} = Context) ->
                       [TcpPortStr]),
                     throw({exit, ex_config})
             end
-    end.
-
-%% -------------------------------------------------------------------
-%%
-%% NOTIFY_SOCKET [Linux only]
-%%   Default: unset
-
-systemd_notify_socket(Context) ->
-    case get_env_var("NOTIFY_SOCKET") of
-        false ->
-            update_context(Context,
-                           systemd_notify_socket, undefined, default);
-        Socket ->
-            update_context(Context,
-                           systemd_notify_socket, Socket, environment)
     end.
 
 %% -------------------------------------------------------------------

--- a/test/rabbit_env_SUITE.erl
+++ b/test/rabbit_env_SUITE.erl
@@ -177,7 +177,6 @@ check_default_values(_) ->
       plugins_path => default,
       quorum_queue_dir => default,
       rabbitmq_home => default,
-      systemd_notify_socket => default,
       upgrade_log_file => default
      },
 
@@ -218,7 +217,6 @@ check_default_values(_) ->
          rabbitmq_home => maps:get(rabbitmq_home, UnixContext),
          split_nodename => rabbit_nodes_common:parts(Node),
          sys_prefix => "",
-         systemd_notify_socket => undefined,
          upgrade_log_file =>
            "/var/log/rabbitmq/" ++ NodeS ++ "_upgrade.log",
 
@@ -262,7 +260,6 @@ check_default_values(_) ->
          rabbitmq_base => "%APPDATA%/RabbitMQ",
          rabbitmq_home => maps:get(rabbitmq_home, Win32Context),
          split_nodename => rabbit_nodes_common:parts(Node),
-         systemd_notify_socket => undefined,
          upgrade_log_file =>
            "%APPDATA%/RabbitMQ/log/" ++ NodeS ++ "_upgrade.log",
 
@@ -377,7 +374,6 @@ check_values_from_reachable_remote_node(Config) ->
           plugins_path => remote_node,
           quorum_queue_dir => default,
           rabbitmq_home => default,
-          systemd_notify_socket => default,
           upgrade_log_file => default
          },
 
@@ -416,7 +412,6 @@ check_values_from_reachable_remote_node(Config) ->
              rabbitmq_home => maps:get(rabbitmq_home, UnixContext),
              split_nodename => rabbit_nodes_common:parts(Node),
              sys_prefix => "",
-             systemd_notify_socket => undefined,
              upgrade_log_file =>
                "/var/log/rabbitmq/" ++ NodeS ++ "_upgrade.log",
 
@@ -488,7 +483,6 @@ check_values_from_offline_remote_node(_) ->
       plugins_path => default,
       quorum_queue_dir => default,
       rabbitmq_home => default,
-      systemd_notify_socket => default,
       upgrade_log_file => default
      },
 
@@ -527,7 +521,6 @@ check_values_from_offline_remote_node(_) ->
          rabbitmq_home => maps:get(rabbitmq_home, UnixContext),
          split_nodename => rabbit_nodes_common:parts(Node),
          sys_prefix => "",
-         systemd_notify_socket => undefined,
          upgrade_log_file =>
            "/var/log/rabbitmq/" ++ NodeS ++ "_upgrade.log",
 


### PR DESCRIPTION
The env var is now handled directly by rabbitmq_prelaunch rabbit_boot_state_systemd

Should be merged after https://github.com/rabbitmq/rabbitmq-server/pull/2231