### PR TITLE
Handle and raise protocol error for absent queues assumed to be alive

### DIFF
--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -331,7 +331,7 @@ absent(#amqqueue{name = QueueName}, timeout) ->
 
 absent(#amqqueue{name = QueueName, pid = QPid}, alive) ->
    protocol_error(not_found,
-                  "failed to perform operation on ~s due to its inconsistent pid ~s",
+                  "failed to perform operation on ~s: its master replica ~w may be stopping or being demoted",
                   [rs(QueueName), QPid]).
 
 type_class(byte)          -> int;

--- a/src/rabbit_misc.erl
+++ b/src/rabbit_misc.erl
@@ -327,7 +327,12 @@ absent(#amqqueue{name = QueueName}, crashed) ->
 
 absent(#amqqueue{name = QueueName}, timeout) ->
     protocol_error(not_found,
-                   "failed to perform operation on ~s due to timeout", [rs(QueueName)]).
+                   "failed to perform operation on ~s due to timeout", [rs(QueueName)]);
+
+absent(#amqqueue{name = QueueName, pid = QPid}, alive) ->
+   protocol_error(not_found,
+                  "failed to perform operation on ~s due to its inconsistent pid ~s",
+                  [rs(QueueName), QPid]).
 
 type_class(byte)          -> int;
 type_class(short)         -> int;


### PR DESCRIPTION
Same as https://github.com/rabbitmq/rabbitmq-server/pull/2233 for **v3.7.x**.

(We actually need this for a v3.7.x release)