### PR TITLE
rabbit_env: Add `$RABBITMQ_CONFIG_FILES`

### DIFF
--- a/src/rabbit_env.erl
+++ b/src/rabbit_env.erl
@@ -42,6 +42,7 @@
          "RABBITMQ_BASE",
          "RABBITMQ_CONF_ENV_FILE",
          "RABBITMQ_CONFIG_FILE",
+         "RABBITMQ_CONFIG_FILES",
          "RABBITMQ_DBG",
          "RABBITMQ_DIST_PORT",
          "RABBITMQ_ENABLED_PLUGINS",
@@ -121,6 +122,7 @@ get_context_after_reloading_env(Context) ->
              fun maybe_setup_dist_for_remote_query/1,
              fun dbg_config/1,
              fun main_config_file/1,
+             fun additional_config_files/1,
              fun advanced_config_file/1,
              fun log_base_dir/1,
              fun main_log_file/1,
@@ -495,10 +497,18 @@ split_nodename(#{nodename := Nodename} = Context) ->
 %%
 %% RABBITMQ_CONFIG_FILE
 %%   Main configuration file.
-%%   Extension is optional. `.config` for the old rlang-term-based
+%%   Extension is optional. `.config` for the old erlang-term-based
 %%   format, `.conf` for the new Cuttlefish-based format.
 %%   Default: (Unix) ${SYS_PREFIX}/etc/rabbitmq/rabbitmq
 %%         (Windows) ${RABBITMQ_BASE}\rabbitmq
+%%
+%% RABBITMQ_CONFIG_FILES
+%%   Additional configuration files.
+%%   If a directory, all files directly inside it are loaded.
+%%   If a glob pattern, all matching file are loaded.
+%%   Only considered if the main configuration file is Cuttlefish-based.
+%%   Default: (Unix) ${SYS_PREFIX}/etc/rabbitmq/conf.d/*.conf
+%%         (Windows) ${RABBITMQ_BASE}\conf.d\*.conf
 %%
 %% RABBITMQ_ADVANCED_CONFIG_FILE
 %%   Advanced configuration file.
@@ -526,6 +536,21 @@ main_config_file(Context) ->
 
 get_default_main_config_file(#{config_base_dir := ConfigBaseDir}) ->
     filename:join(ConfigBaseDir, "rabbitmq").
+
+additional_config_files(Context) ->
+    case get_prefixed_env_var("RABBITMQ_CONFIG_FILES") of
+        false ->
+            Pattern = get_default_additional_config_files(Context),
+            update_context(
+              Context, additional_config_files, Pattern, default);
+        Value ->
+            Pattern = normalize_path(Value),
+            update_context(
+              Context, additional_config_files, Pattern, environment)
+    end.
+
+get_default_additional_config_files(#{config_base_dir := ConfigBaseDir}) ->
+    filename:join([ConfigBaseDir, "conf.d", "*.conf"]).
 
 advanced_config_file(Context) ->
     case get_prefixed_env_var("RABBITMQ_ADVANCED_CONFIG_FILE") of

--- a/test/rabbit_env_SUITE.erl
+++ b/test/rabbit_env_SUITE.erl
@@ -34,6 +34,7 @@
          check_context_to_code_path/1,
          check_RABBITMQ_ADVANCED_CONFIG_FILE/1,
          check_RABBITMQ_CONFIG_FILE/1,
+         check_RABBITMQ_CONFIG_FILES/1,
          check_RABBITMQ_DIST_PORT/1,
          check_RABBITMQ_ENABLED_PLUGINS/1,
          check_RABBITMQ_ENABLED_PLUGINS_FILE/1,
@@ -71,6 +72,7 @@ all() ->
      check_context_to_code_path,
      check_RABBITMQ_ADVANCED_CONFIG_FILE,
      check_RABBITMQ_CONFIG_FILE,
+     check_RABBITMQ_CONFIG_FILES,
      check_RABBITMQ_DIST_PORT,
      check_RABBITMQ_ENABLED_PLUGINS,
      check_RABBITMQ_ENABLED_PLUGINS_FILE,
@@ -156,6 +158,7 @@ check_default_values(_) ->
     NodeS = atom_to_list(Node),
 
     Origins = #{
+      additional_config_files => default,
       advanced_config_file => default,
       amqp_ipaddr => default,
       amqp_tcp_port => default,
@@ -190,7 +193,8 @@ check_default_values(_) ->
      },
 
     ?assertEqual(
-       #{advanced_config_file => "/etc/rabbitmq/advanced.config",
+       #{additional_config_files => "/etc/rabbitmq/conf.d/*.conf",
+         advanced_config_file => "/etc/rabbitmq/advanced.config",
          amqp_ipaddr => "auto",
          amqp_tcp_port => 5672,
          conf_env_file => "/etc/rabbitmq/rabbitmq-env.conf",
@@ -236,7 +240,8 @@ check_default_values(_) ->
        UnixContext),
 
     ?assertEqual(
-       #{advanced_config_file => "%APPDATA%/RabbitMQ/advanced.config",
+       #{additional_config_files => "%APPDATA%/RabbitMQ/conf.d/*.conf",
+         advanced_config_file => "%APPDATA%/RabbitMQ/advanced.config",
          amqp_ipaddr => "auto",
          amqp_tcp_port => 5672,
          conf_env_file => "%APPDATA%/RabbitMQ/rabbitmq-env-conf.bat",
@@ -362,6 +367,7 @@ check_values_from_reachable_remote_node(Config) ->
         {RFFValue, RFFOrigin} = forced_feature_flags_on_init_expect(),
 
         Origins = #{
+          additional_config_files => default,
           advanced_config_file => default,
           amqp_ipaddr => default,
           amqp_tcp_port => default,
@@ -396,7 +402,8 @@ check_values_from_reachable_remote_node(Config) ->
          },
 
         ?assertEqual(
-           #{advanced_config_file => "/etc/rabbitmq/advanced.config",
+           #{additional_config_files => "/etc/rabbitmq/conf.d/*.conf",
+             advanced_config_file => "/etc/rabbitmq/advanced.config",
              amqp_ipaddr => "auto",
              amqp_tcp_port => 5672,
              conf_env_file => "/etc/rabbitmq/rabbitmq-env.conf",
@@ -477,6 +484,7 @@ check_values_from_offline_remote_node(_) ->
     {RFFValue, RFFOrigin} = forced_feature_flags_on_init_expect(),
 
     Origins = #{
+      additional_config_files => default,
       advanced_config_file => default,
       amqp_ipaddr => default,
       amqp_tcp_port => default,
@@ -511,7 +519,8 @@ check_values_from_offline_remote_node(_) ->
      },
 
     ?assertEqual(
-       #{advanced_config_file => "/etc/rabbitmq/advanced.config",
+       #{additional_config_files => "/etc/rabbitmq/conf.d/*.conf",
+         advanced_config_file => "/etc/rabbitmq/advanced.config",
          amqp_ipaddr => "auto",
          amqp_tcp_port => 5672,
          conf_env_file => "/etc/rabbitmq/rabbitmq-env.conf",
@@ -664,6 +673,15 @@ check_RABBITMQ_CONFIG_FILE(_) ->
     Value2 = random_string(),
     check_prefixed_variable("RABBITMQ_CONFIG_FILE",
                             main_config_file,
+                            '_',
+                            Value1, Value1,
+                            Value2, Value2).
+
+check_RABBITMQ_CONFIG_FILES(_) ->
+    Value1 = random_string(),
+    Value2 = random_string(),
+    check_prefixed_variable("RABBITMQ_CONFIG_FILES",
+                            additional_config_files,
                             '_',
                             Value1, Value1,
                             Value2, Value2).


### PR DESCRIPTION
It is used to specify additional configuration files when using the Cuttlefish format.

Required by rabbitmq/rabbitmq-server#2258.