### PR TITLE
Bump minimum requirement to Erlang/OTP 21.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 elixir:
   - '1.9'
 otp_release:
-  - '20.3'
+  - '21.3'
   - '22.2'
 
 install:

--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -234,8 +234,8 @@
 
 -define(COPYRIGHT_MESSAGE, "Copyright (c) 2007-2020 Pivotal Software, Inc.").
 -define(INFORMATION_MESSAGE, "Licensed under the MPL.  See https://www.rabbitmq.com/").
--define(OTP_MINIMUM, "20.3").
--define(ERTS_MINIMUM, "9.3").
+-define(OTP_MINIMUM, "21.3").
+-define(ERTS_MINIMUM, "10.3").
 
 %% EMPTY_FRAME_SIZE, 8 = 1 + 2 + 4 + 1
 %%  - 1 byte of frame type


### PR DESCRIPTION
We already announced and document that RabbitMQ 3.7.x requires Erlang/OTP 21.3.

This commit makes it effective. This allows us to use the new `try Class:Reason:Stacktrace` syntax introduced in Erlang/OTP 21.0 and unbreak RabbitMQ 3.7.x with the upcoming Erlang/OTP 23.0.