### PR TITLE
Move the location of the 'enabled_plugins' file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /sbin/
 /sbin.lock
 /test/ct.cover.spec
+/test/*_SUITE_data/
 /xrefr
 
 /rabbit_common.d

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 /sbin/
 /sbin.lock
 /test/ct.cover.spec
-/test/*_SUITE_data/
 /xrefr
 
 /rabbit_common.d


### PR DESCRIPTION
In response to https://github.com/rabbitmq/rabbitmq-server/issues/2234

Move the location of the `enabled_plugins` file from `/etc/rabbitmq` to `/var/lib/rabbitmq` on unix, but fallback to the original location if there is no file at the new location, and the file at the old location is both readable and writable.