### PR TITLE
rabbitmq-dist.mk: Fix incorrect quoting in install-cli-scripts

### DIFF
--- a/mk/rabbitmq-dist.mk
+++ b/mk/rabbitmq-dist.mk
@@ -324,7 +324,7 @@ install-cli-scripts:
 		done'; \
 	else \
 		mkdir -p "$(CLI_SCRIPTS_DIR)" && \
-		for file in "'$$rabbit_scripts_dir'"/*; do \
+		for file in "$$rabbit_scripts_dir"/*; do \
 			test -f "$$file"; \
 			cmp -s "$$file" "$(CLI_SCRIPTS_DIR)/$$(basename "$$file")" || \
 			cp -a "$$file" "$(CLI_SCRIPTS_DIR)/$$(basename "$$file")"; \


### PR DESCRIPTION
The double-quoting was requited in the flock(1)/lockf(1) blocks because of the use of `sh -c`. However it's incorrect in the `else` block.

Follow-up to commit 1bfff5bb49aa8da5653458c7a4c6ff52eeebe9ff.