### PR TITLE
rabbitmq-tools.mk: New `rabbitmq-deps.mk` target

### DIFF
--- a/mk/rabbitmq-tools.mk
+++ b/mk/rabbitmq-tools.mk
@@ -396,3 +396,33 @@ clean-ct-logs-archive::
 	$(gen_verbose) rm -f $(PROJECT)-ct-logs-*.tar.xz
 
 clean:: clean-ct-logs-archive
+
+# --------------------------------------------------------------------
+# Generate a file listing RabbitMQ component dependencies and their
+# Git commit hash.
+# --------------------------------------------------------------------
+
+.PHONY: rabbitmq-deps.mk clean-rabbitmq-deps.mk
+
+rabbitmq-deps.mk: $(PROJECT)-rabbitmq-deps.mk
+	@:
+
+closing_paren := )
+
+define rmq_deps_mk_line
+dep_$(1) := git $(dir $(RABBITMQ_UPSTREAM_FETCH_URL))$(call rmq_cmp_repo_name,$(1)).git $$(git -C "$(2)" rev-parse HEAD)
+endef
+
+$(PROJECT)-rabbitmq-deps.mk: $(ERLANG_MK_RECURSIVE_DEPS_LIST)
+	$(gen_verbose) cat $(ERLANG_MK_RECURSIVE_DEPS_LIST) | \
+	while read -r dir; do \
+	  component=$$(basename "$$dir"); \
+	  case "$$component" in \
+	  $(foreach component,$(RABBITMQ_COMPONENTS),$(component)$(closing_paren) echo "$(call rmq_deps_mk_line,$(component),$$dir)" ;;) \
+	  esac; \
+	done > $@
+
+clean:: clean-rabbitmq-deps.mk
+
+clean-rabbitmq-deps.mk:
+	$(gen_verbose) rm -f $(PROJECT)-rabbitmq-deps.mk


### PR DESCRIPTION
It generates a file called `$(PROJECT)-rabbitmq-deps.mk` which has a dependency definition line of the form expected by Erlang.mk, for each RabbitMQ component the project depends on.

Therefore the line indicates:
* `git` as the fetch method
* the repository URL
* the Git commit hash the dependency is on

Here is an example for rabbitmq-server:

    dep_rabbit_common := git https://github.com/rabbitmq/rabbitmq-common.git d9ccd8d9cdd58310901f318fed676aff59be5afb
    dep_rabbitmq_cli := git https://github.com/rabbitmq/rabbitmq-cli.git f6eaae292d27da4ded92b7c1b51a8ddcfefa69c2
    dep_rabbitmq_codegen := git https://github.com/rabbitmq/rabbitmq-codegen.git 65da2e86bd65c6b6ecd48478ab092721696bc709