### PR TITLE
Use "hostname -s" only on Darwin/FreeBSD

### DIFF
--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -65,7 +65,7 @@ node_feature_flags_file = $(call node_tmpdir,$(1))/feature_flags
 node_enabled_plugins_file = $(call node_tmpdir,$(1))/enabled_plugins
 
 # Broker startup variables for the test environment.
-HOSTNAME := $(shell hostname -s)
+HOSTNAME := $(shell U="$$(uname)"; if [ "$$U" = Darwin -o "$$U" = FreeBSD  ]; then hostname -s; else hostname; fi)
 RABBITMQ_NODENAME ?= rabbit@$(HOSTNAME)
 RABBITMQ_NODENAME_FOR_PATHS ?= $(RABBITMQ_NODENAME)
 NODE_TMPDIR ?= $(call node_tmpdir,$(RABBITMQ_NODENAME_FOR_PATHS))
@@ -367,7 +367,7 @@ NODES ?= 2
 
 start-brokers start-cluster: $(DIST_TARGET)
 	@for n in $$(seq $(NODES)); do \
-		nodename="rabbit-$$n@$$(hostname -s)"; \
+		nodename="rabbit-$$n@$(HOSTNAME)"; \
 		$(MAKE) start-background-broker \
 		  NOBUILD=1 \
 		  RABBITMQ_NODENAME="$$nodename" \
@@ -393,7 +393,7 @@ start-brokers start-cluster: $(DIST_TARGET)
 
 stop-brokers stop-cluster:
 	@for n in $$(seq $(NODES) -1 1); do \
-		nodename="rabbit-$$n@$$(hostname -s)"; \
+		nodename="rabbit-$$n@$(HOSTNAME)"; \
 		$(MAKE) stop-node \
 		  RABBITMQ_NODENAME="$$nodename"; \
 	done

--- a/mk/rabbitmq-run.mk
+++ b/mk/rabbitmq-run.mk
@@ -65,7 +65,12 @@ node_feature_flags_file = $(call node_tmpdir,$(1))/feature_flags
 node_enabled_plugins_file = $(call node_tmpdir,$(1))/enabled_plugins
 
 # Broker startup variables for the test environment.
-HOSTNAME := $(shell U="$$(uname)"; if [ "$$U" = Darwin -o "$$U" = FreeBSD  ]; then hostname -s; else hostname; fi)
+ifeq ($(PLATFORM),msys2)
+HOSTNAME := $(COMPUTERNAME)
+else
+HOSTNAME := $(shell hostname -s)
+endif
+
 RABBITMQ_NODENAME ?= rabbit@$(HOSTNAME)
 RABBITMQ_NODENAME_FOR_PATHS ?= $(RABBITMQ_NODENAME)
 NODE_TMPDIR ?= $(call node_tmpdir,$(RABBITMQ_NODENAME_FOR_PATHS))

--- a/mk/rabbitmq-tools.mk
+++ b/mk/rabbitmq-tools.mk
@@ -1,4 +1,8 @@
-HOSTNAME := $(shell U="$$(uname)"; if [ "$$U" = Darwin -o "$$U" = FreeBSD  ]; then hostname -s; else hostname; fi)
+ifeq ($(PLATFORM),msys2)
+HOSTNAME := $(COMPUTERNAME)
+else
+HOSTNAME := $(shell hostname -s)
+endif
 
 READY_DEPS = $(foreach DEP,\
 	       $(filter $(RABBITMQ_COMPONENTS),$(DEPS) $(BUILD_DEPS) $(TEST_DEPS)), \

--- a/mk/rabbitmq-tools.mk
+++ b/mk/rabbitmq-tools.mk
@@ -1,3 +1,5 @@
+HOSTNAME := $(shell U="$$(uname)"; if [ "$$U" = Darwin -o "$$U" = FreeBSD  ]; then hostname -s; else hostname; fi)
+
 READY_DEPS = $(foreach DEP,\
 	       $(filter $(RABBITMQ_COMPONENTS),$(DEPS) $(BUILD_DEPS) $(TEST_DEPS)), \
 	       $(if $(wildcard $(DEPS_DIR)/$(DEP)),$(DEP),))
@@ -361,7 +363,7 @@ ifeq ($(PLATFORM),darwin)
 TAR := gtar
 endif
 
-CT_LOGS_ARCHIVE ?= $(PROJECT)-ct-logs-$(subst _,-,$(subst -,,$(subst .,,$(patsubst ct_run.ct_$(PROJECT)@$(shell hostname -s).%,%,$(notdir $(lastword $(wildcard logs/ct_run.*))))))).tar.xz
+CT_LOGS_ARCHIVE ?= $(PROJECT)-ct-logs-$(subst _,-,$(subst -,,$(subst .,,$(patsubst ct_run.ct_$(PROJECT)@$(HOSTNAME).%,%,$(notdir $(lastword $(wildcard logs/ct_run.*))))))).tar.xz
 
 ifeq ($(patsubst %.tar.xz,%,$(CT_LOGS_ARCHIVE)),$(CT_LOGS_ARCHIVE))
 $(error CT_LOGS_ARCHIVE file must use '.tar.xz' as its filename extension)


### PR DESCRIPTION
Fixes #374

Tested on FreeBSD 12 and Debian Buster. Ran `run-broker` and `start-cluster` on each, worked as expected.

On Windows using msys2, `run-broker` works. `start-cluster` needs work, but not related to this.