### PR TITLE
rabbit_env: Add get_used_env_vars/0 to fetch variables used by rabbit_env

### DIFF
--- a/src/rabbit_env.erl
+++ b/src/rabbit_env.erl
@@ -25,6 +25,7 @@
          get_context_after_logging_init/1,
          get_context_after_reloading_env/1,
          dbg_config/0,
+         get_used_env_vars/0,
          log_process_env/0,
          log_context/1,
          context_to_app_env_vars/1,
@@ -214,6 +215,11 @@ update_context(Context, Key, Value, Origin)
   when ?origin_is_valid(Origin) ->
     Context#{Key => Value,
              var_origins => #{Key => Origin}}.
+
+get_used_env_vars() ->
+    lists:filter(
+      fun({Var, _}) -> var_is_used(Var) end,
+      lists:sort(os:list_env_vars())).
 
 log_process_env() ->
     rabbit_log_prelaunch:debug("Process environment:"),
@@ -1623,6 +1629,8 @@ get_prefixed_env_var("RABBITMQ_" ++ Suffix = VarName,
 
 var_is_used("RABBITMQ_" ++ _ = PrefixedVar) ->
     lists:member(PrefixedVar, ?USED_ENV_VARS);
+var_is_used("HOME") ->
+    false;
 var_is_used(Var) ->
     lists:member("RABBITMQ_" ++ Var, ?USED_ENV_VARS).
 

--- a/test/rabbit_env_SUITE.erl
+++ b/test/rabbit_env_SUITE.erl
@@ -59,7 +59,8 @@
          check_RABBITMQ_USE_LOGNAME/1,
          check_value_is_yes/1,
          check_log_process_env/1,
-         check_log_context/1
+         check_log_context/1,
+         check_get_used_env_vars/1
         ]).
 
 all() ->
@@ -97,7 +98,8 @@ all() ->
      check_RABBITMQ_USE_LOGNAME,
      check_value_is_yes,
      check_log_process_env,
-     check_log_context
+     check_log_context,
+     check_get_used_env_vars
     ].
 
 suite() ->
@@ -952,6 +954,17 @@ check_log_process_env(_) ->
 check_log_context(_) ->
     Context = rabbit_env:get_context(),
     ok = rabbit_env:log_context(Context).
+
+check_get_used_env_vars(_) ->
+    os:putenv("RABBITMQ_LOGS", "-"),
+    os:putenv("CONFIG_FILE", "filename"),
+    Vars = rabbit_env:get_used_env_vars(),
+    ?assert(lists:keymember("RABBITMQ_LOGS", 1, Vars)),
+    ?assert(lists:keymember("CONFIG_FILE", 1, Vars)),
+    ?assertNot(lists:keymember("HOME", 1, Vars)),
+    ?assertNot(lists:keymember("PATH", 1, Vars)),
+    os:unsetenv("RABBITMQ_LOGS"),
+    os:unsetenv("CONFIG_FILE").
 
 check_variable(Variable, Key, ValueToSet, Comparison) ->
     os:putenv(Variable, ValueToSet),


### PR DESCRIPTION
... and their value.

Both prefixed and non-prefixed variables are returned by this function.

While here, fix a conflict between `$RABBITMQ_HOME` and `$HOME` in `var_is_used/1`: the latter shouldn't be considered as used.