### PR TITLE
Update credentials_obfuscation dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endef
 LOCAL_DEPS = compiler crypto public_key sasl ssl syntax_tools tools xmerl
 DEPS = lager jsx ranch recon credentials_obfuscation
 
-dep_credentials_obfuscation = hex 1.1.0
+dep_credentials_obfuscation = hex 1.2.0
 
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
 # reviewed and merged.


### PR DESCRIPTION
Part of rabbitmq/credentials_obfuscation#2

Do not merge until https://github.com/rabbitmq/credentials-obfuscation/pull/4 is resolved and version 1.2.0 is pushed to hex.