### PR TITLE
Add a specific shutdown timeout macro and property for message stores

### DIFF
--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -210,6 +210,8 @@
         rabbit_misc:get_env(rabbit, supervisor_shutdown_timeout, infinity)).
 -define(WORKER_WAIT,
         rabbit_misc:get_env(rabbit, worker_shutdown_timeout, 30000)).
+-define(MSG_STORE_WORKER_WAIT,
+        rabbit_misc:get_env(rabbit, message_store_shutdown_timeout, 600000)).
 
 -define(HIBERNATE_AFTER_MIN,        1000).
 -define(DESIRED_HIBERNATE,         10000).

--- a/include/rabbit.hrl
+++ b/include/rabbit.hrl
@@ -211,7 +211,7 @@
 -define(WORKER_WAIT,
         rabbit_misc:get_env(rabbit, worker_shutdown_timeout, 30000)).
 -define(MSG_STORE_WORKER_WAIT,
-        rabbit_misc:get_env(rabbit, message_store_shutdown_timeout, 600000)).
+        rabbit_misc:get_env(rabbit, msg_store_shutdown_timeout, 600000)).
 
 -define(HIBERNATE_AFTER_MIN,        1000).
 -define(DESIRED_HIBERNATE,         10000).


### PR DESCRIPTION
The default timeout of 30 seconds was not sufficient to allow graceful shutdown of a message store with millions of persistent messages. Rather than increase the timeout in general, introduce a new macro with a default of 600 seconds