### PR TITLE
rabbit_env: Give precedence to $RABBITMQ_* prefixed variables in the output of $CONF_ENV_FILE

### DIFF
--- a/src/rabbit_env.erl
+++ b/src/rabbit_env.erl
@@ -1715,9 +1715,12 @@ var_is_used("HOME") ->
 var_is_used(Var) ->
     lists:member("RABBITMQ_" ++ Var, ?USED_ENV_VARS).
 
-var_is_set("RABBITMQ_" ++ Var = PrefixedVar) ->
-    os:getenv(PrefixedVar) /= false orelse
-    os:getenv(Var) /= false;
+%% The $RABBITMQ_* variables have precedence over their un-prefixed equivalent.
+%% Therefore, when we check if $RABBITMQ_* is set, we only look at this
+%% variable. However, when we check if an un-prefixed variable is set, we first
+%% look at its $RABBITMQ_* variant.
+var_is_set("RABBITMQ_" ++ _ = PrefixedVar) ->
+    os:getenv(PrefixedVar) /= false;
 var_is_set(Var) ->
     os:getenv("RABBITMQ_" ++ Var) /= false orelse
     os:getenv(Var) /= false.


### PR DESCRIPTION
When we source the `$CONF_ENV_FILE` script, we set a few variables which this script expects. Those variables are given without their prefix. For instance, `$MNESIA_BASE`.

The `$CONF_ENV_FILE` script can set `$RABBITMQ_MNESIA_BASE`. Unfortunately before this patch, the variable would be ignored, in favor of the default value which was passed to the script (`$MNESIA_BASE`).

The reason is that variables set by the script are handled in the alphabetical order. Thus `$MNESIA_BASE` is handled first, then `$RABBITMQ_MNESIA_BASE`.

Because the code didn't give any precedence, the first variable set would "win". This explains why users who set `$RABBITMQ_MNESIA_BASE` in `$CONF_ENV_FILE`, but using RabbitMQ 3.8.4+ (which introduced `rabbit_env`), unexpectedly had their node use the default Mnesia base directory.

The patch is rather simple: when we check if a variable is already set, we give precedence to the `$RABBITMQ_*` prefixed variables. Therefore, if the `$CONF_ENV_FILE` script sets `$RABBITMQ_MNESIA_BASE`, this value will be used, regardless of the value of `$MNESIA_BASE`.

This didn't happen with variables set in the environment (i.e. the environment of rabbitmq-server(8)) because the prefixed variables already had precedence.

Fixes rabbitmq/rabbitmq-common#401.