### PR TITLE
Avoid using os:find_executable to find erl

### DIFF
--- a/src/rabbit_nodes_common.erl
+++ b/src/rabbit_nodes_common.erl
@@ -72,14 +72,7 @@ epmd_port() ->
     end.
 
 ensure_epmd() ->
-    {ok, [[Prog]]} = init:get_argument(progname),
-    Exe = os:find_executable(Prog),
-    do_ensure_epmd(Exe, Prog).
-
-do_ensure_epmd(false, Prog) ->
-    Path = os:getenv("PATH"),
-    rabbit_log:error("ensure_epmd: unable to find executable '~s' in PATH: '~s'", [Prog, Path]);
-do_ensure_epmd(Exe, _) ->
+    Exe = rabbit_runtime:get_erl_path(),
     ID = rabbit_misc:random(1000000000),
     Port = open_port(
              {spawn_executable, Exe},

--- a/src/rabbit_runtime.erl
+++ b/src/rabbit_runtime.erl
@@ -16,7 +16,7 @@
 
 -export([guess_number_of_cpu_cores/0, msacc_stats/1]).
 -export([get_gc_info/1, gc_all_processes/0]).
-
+-export([get_erl_path/0]).
 
 -spec guess_number_of_cpu_cores() -> pos_integer().
 guess_number_of_cpu_cores() ->
@@ -52,3 +52,15 @@ msacc_stats(TimeInMs) ->
     S = msacc:stats(),
     msacc:stop(),
     S.
+
+% get the full path to the erl executable used to start this VM
+-spec get_erl_path() -> file:filename_all().
+get_erl_path() ->
+    {ok, [[Root]]} = init:get_argument(root),
+    Bin = filename:join(Root, "bin"),
+    case os:type() of
+        {win32, _} ->
+            filename:join(Bin, "erl.exe");
+        _ ->
+            filename:join(Bin, "erl")
+    end.

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -37,7 +37,8 @@ groups() ->
             platform_and_version,
             frame_encoding_does_not_fail_with_empty_binary_payload,
             amqp_table_conversion,
-            name_type
+            name_type,
+            get_erl_path
         ]},
         {parse_mem_limit, [parallel], [
             parse_mem_limit_relative_exactly_max,
@@ -432,4 +433,14 @@ name_type(_) ->
     ?assertEqual(shortnames, rabbit_nodes_common:name_type(rabbit)),
     ?assertEqual(shortnames, rabbit_nodes_common:name_type(rabbit@localhost)),
     ?assertEqual(longnames, rabbit_nodes_common:name_type('rabbit@localhost.example.com')),
+    ok.
+
+get_erl_path(_) ->
+    Exe = rabbit_runtime:get_erl_path(),
+    case os:type() of
+        {win32, _} ->
+            ?assertNotMatch(nomatch, string:find(Exe, "erl.exe"));
+        _ ->
+            ?assertNotMatch(nomatch, string:find(Exe, "erl"))
+    end,
     ok.


### PR DESCRIPTION
On Windows, the current working directory is also searched, which can
lead to problems. Instead, use `init:get_argument(root)` to get the root
of the Erlang release, then we know `bin/erl` will always be present.

![procmon-find_executable-win32](https://user-images.githubusercontent.com/514926/89458323-b476e100-d71b-11ea-8490-f77266e4c3ad.png)
