### PR TITLE
rabbitmq-dist.mk: Package plugins as directories by default instead of .ez archives

### DIFF
--- a/mk/rabbitmq-dist.mk
+++ b/mk/rabbitmq-dist.mk
@@ -5,10 +5,12 @@ CLI_SCRIPTS_DIR = sbin
 CLI_ESCRIPTS_DIR = escript
 MIX = echo y | mix
 
+# Set $(DIST_AS_EZS) to a non-empty value to enable the packaging of
+# plugins as .ez archives.
 ifeq ($(USE_RABBIT_BOOT_SCRIPT),)
-DIST_AS_EZS ?= true
-else
 DIST_AS_EZS ?=
+else
+DIST_AS_EZS =
 endif
 
 dist_verbose_0 = @echo " DIST  " $@;


### PR DESCRIPTION
The benefits for doing this:

* We can use native code, as is the case for lz4 and zstd bindings in the Tanzu RabbitMQ version for instance. Indeed, Erlang does not support loading native code (NIF or port drivers) from .ez archives.
* We can remove custom code to handle .ez archives. We have special cases in Erlang.mk plugins as well as the `rabbit_plugins` module, in particular the code to extract .ez archives (even though Erlang knows how to use them directly).
* Prevent hard to debug situations when the .ez archive name does not match the top-level directory inside the archive. In this case, Erlang says it can't load the application but doesn't tell much more.
* Debugging and "hot-patching" plugins become easier: we just have to copy the recompiled .beam file in place of the existing one. There is no need to unpack the plugin, replace the file and recreate the archive.
* Release packages can be smaller. gzip, bzip2 and xz, common compression algorithm for Unix packages, give much better result if they compress the .beam files directly instead of "compressing" zip files (the .ez archives are plain zip archives). For instance, the generic-unix package goes from 15 MiB when using .ez archives to just 12 MiB when using directory.

I would also like to experiment with Erlang releases in the future.  Using directories for Erlang applications instead of .ez archives is mandatory for this to work according to my latest tests.

Of course, this change doesn't break support for .ez archives (and we will keep support for this). End users can still download third-party plugins as .ez archives and drop them in the plugins directory.
