### PR TITLE
remove TLSv1.3 from BAD_SSL_PROTOCOL_VERSIONS

### DIFF
--- a/src/rabbit_ssl_options.erl
+++ b/src/rabbit_ssl_options.erl
@@ -12,18 +12,7 @@
 
 -define(BAD_SSL_PROTOCOL_VERSIONS, [
                                     %% POODLE
-                                    sslv3,
-
-                                    %% Client side of TLS 1.3 is not yet
-                                    %% implemented in Erlang/OTP 22.0
-                                    %% prereleases. As a consequence,
-                                    %% not sure about the stability of
-                                    %% the server side.
-                                    %%
-                                    %% FIXME: Revisit this decision when
-                                    %% Erlang/OTP 22.0 final release is
-                                    %% out.
-                                    'tlsv1.3'
+                                    sslv3
                                    ]).
 
 -spec fix(rabbit_types:infos()) -> rabbit_types:infos().


### PR DESCRIPTION
As OTP23 is released and is supporting TLSv1.3 by default, removed TLSv1.3 from list of bad SSL protocols