### PR TITLE
Update Cowboy to 2.8.0

### DIFF
--- a/mk/rabbitmq-components.mk
+++ b/mk/rabbitmq-components.mk
@@ -111,8 +111,8 @@ dep_rabbitmq_public_umbrella          = git_rmq rabbitmq-public-umbrella $(curre
 # possible to work with rabbitmq-public-umbrella.
 
 dep_accept = hex 0.3.5
-dep_cowboy = hex 2.6.1
-dep_cowlib = hex 2.7.0
+dep_cowboy = hex 2.8.0
+dep_cowlib = hex 2.9.1
 dep_jsx = hex 2.11.0
 dep_lager = hex 3.8.0
 dep_prometheus = git https://github.com/deadtrickster/prometheus.erl.git master


### PR DESCRIPTION
This will enable stacktraces in the logs again.

The `rabbitmq-components.mk` file will need to be updated in all repositories. /cc @dumbbell 

I have tested this against auth_backend_http, auth_backend_oauth2, management, web_dispatch, web_mqtt, web_stomp and everything is green. Therefore I do not think there needs to be any code change to upgrade. /cc @michaelklishin 